### PR TITLE
feat(postcodes/NL): 4,072 Dutch PC4 postcodes (#1039)

### DIFF
--- a/bin/scripts/sync/import_netherlands_postcodes.py
+++ b/bin/scripts/sync/import_netherlands_postcodes.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Netherlands -> contributions/postcodes/NL.json importer for issue #1039.
+
+Source data
+-----------
+The community ``mevdschee/postcodes-nl`` GitHub release ships a
+17 MB 7zip archive containing a 401 MB CSV with all Dutch street-
+level address data joining each postcode (PC6: 4-digit + 2-letter)
+to a woonplaats (settlement).
+
+Source URL: https://github.com/mevdschee/postcodes-nl/releases/latest
+
+What this script does
+---------------------
+1. Resolves the latest release via the GitHub API.
+2. Fetches the 17 MB 7zip and extracts the CSV in-memory via py7zr.
+3. Aggregates 9M+ street-level rows into 4,072 unique PC4
+   (4-digit) districts, picking the most-common woonplaats per PC4
+   as the representative locality.
+4. Writes contributions/postcodes/NL.json idempotently.
+
+Why PC4 (not PC6)
+-----------------
+Unique PC6 codes total 467,109. JSON-export at PC6 level would
+exceed the in-band cities/*.json size envelope (PT.json at 38 MB
+is the current largest; PC6 expansion would be ~70 MB).
+
+PC4 (4-digit) is the standard Dutch district-level postcode
+granularity (~4,000 districts), comparable to UK postcode areas
+and Canada FSAs already shipped at this scale.
+
+Why country-only state FK
+-------------------------
+The Netherlands' 12 provinces span PC4 ranges with significant
+overlap (e.g. PC4 1xxx covers parts of Noord-Holland and Flevoland).
+A 1:1 PC4 -> province map would be misleading. CSC matches the
+SE / SI / GB precedent for sources that don't map cleanly to a
+hierarchy.
+
+Regex fix
+---------
+Before this PR, countries.json had NL regex `^\\d{4}\\s?[a-zA-Z]{2}$`
+(PC6 only). Updated to `^\\d{4}(?:\\s?[A-Za-z]{2})?$` to accept
+PC4 also, matching the mixed-granularity pattern already permitted
+for GB / TW / CA / IR.
+
+Dependency
+----------
+- ``py7zr`` (LGPL, pure-Python 7zip reader). Install via:
+    python3 -m pip install py7zr
+
+License & attribution
+---------------------
+- Source: mevdschee/postcodes-nl (LGPL-3 per repo LICENSE)
+- Upstream: Dutch Kadaster / BAG (Basisregistratie Adressen en
+  Gebouwen), public open-data lookup
+- Each row: ``source: "bag-via-mevdschee"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_netherlands_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import csv
+import io
+import json
+import os
+import re
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+import py7zr
+
+
+RELEASES_API = "https://api.github.com/repos/mevdschee/postcodes-nl/releases/latest"
+
+
+def fetch_bytes(url: str) -> bytes:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=600) as r:
+        return r.read()
+
+
+def resolve_archive_url() -> str:
+    req = urllib.request.Request(
+        RELEASES_API, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        meta = json.loads(r.read())
+    for asset in meta.get("assets", []):
+        if asset.get("name", "").endswith(".7z"):
+            return asset["browser_download_url"]
+    raise RuntimeError("No .7z asset in latest release")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local 7z (skip fetch)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if args.input:
+        raw = Path(args.input).read_bytes()
+    else:
+        url = resolve_archive_url()
+        print(f"fetching {url}")
+        raw = fetch_bytes(url)
+    print(f"7z size: {len(raw):,} bytes")
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    nl_country = next((c for c in countries if c.get("iso2") == "NL"), None)
+    if nl_country is None:
+        print("ERROR: NL not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(nl_country.get("postal_code_regex") or ".*")
+    print(f"Country: Netherlands (id={nl_country['id']})")
+
+    # Aggregate to PC4 with most-common woonplaats per PC4
+    pc4_woonplaatsen: Dict[str, collections.Counter] = collections.defaultdict(
+        collections.Counter
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        with py7zr.SevenZipFile(io.BytesIO(raw), mode="r") as archive:
+            archive.extractall(path=tmp)
+        csv_path = next(
+            os.path.join(tmp, n)
+            for n in os.listdir(tmp)
+            if n.endswith(".csv")
+        )
+        print(f"CSV: {os.path.getsize(csv_path):,} bytes")
+        with open(csv_path, encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for i, row in enumerate(reader):
+                if i and i % 2_000_000 == 0:
+                    print(f"  processed {i:,}")
+                pc = (row.get("postcode") or "").replace(" ", "").upper()
+                wp = (row.get("woonplaats") or "").strip()
+                if len(pc) >= 4 and pc[:4].isdigit():
+                    pc4_woonplaatsen[pc[:4]][wp] += 1
+
+    print(f"unique PC4: {len(pc4_woonplaatsen):,}")
+
+    records: List[dict] = []
+    skipped_bad_regex = 0
+
+    for pc4 in sorted(pc4_woonplaatsen):
+        if not regex.match(pc4):
+            skipped_bad_regex += 1
+            continue
+        wp = pc4_woonplaatsen[pc4].most_common(1)[0][0]
+
+        record: Dict[str, object] = {
+            "code": pc4,
+            "country_id": int(nl_country["id"]),
+            "country_code": "NL",
+        }
+        if wp:
+            record["locality_name"] = wp
+        record["type"] = "area"
+        record["source"] = "bag-via-mevdschee"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/NL.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/countries/countries.json
+++ b/contributions/countries/countries.json
@@ -10434,8 +10434,8 @@
     "subregion_id": 17,
     "nationality": "Dutch, Netherlandic",
     "area_sq_km": 41526.0,
-    "postal_code_format": "#### @@",
-    "postal_code_regex": "^(\\d{4}\\s?[a-zA-Z]{2})$",
+    "postal_code_format": "####|#### @@",
+    "postal_code_regex": "^(\\d{4}(?:\\s?[A-Za-z]{2})?)$",
     "timezones": [
       {
         "zoneName": "Europe/Amsterdam",

--- a/contributions/postcodes/NL.json
+++ b/contributions/postcodes/NL.json
@@ -1,0 +1,32578 @@
+[
+  {
+    "code": "1011",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1012",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1013",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1014",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1015",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1016",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1017",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1018",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1019",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1021",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1022",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1023",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1024",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1025",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1026",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1027",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1028",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1031",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1032",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1033",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1034",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1035",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1036",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1037",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1041",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1042",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1043",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1044",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1045",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1046",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1047",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1051",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1052",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1053",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1054",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1055",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1056",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1057",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1058",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1059",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1060",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1061",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1062",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1063",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1064",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1065",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1066",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1067",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1068",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1069",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1071",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1072",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1073",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1074",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1075",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1076",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1077",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1078",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1079",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1081",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1082",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1083",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1086",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1087",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1091",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1092",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1093",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1094",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1095",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1096",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1097",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1098",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1101",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1102",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1103",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1104",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1105",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1106",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1107",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1108",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1109",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1111",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Diemen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1112",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Diemen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1113",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Diemen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1114",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amsterdam-Duivendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1115",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Duivendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1117",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiphol",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1118",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiphol",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1119",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiphol-Rijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1121",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Landsmeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1127",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Ilp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1131",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Volendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1132",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Volendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1135",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Edam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1141",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Monnickendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1145",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Katwoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1151",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Broek in Waterland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1153",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuiderwoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1154",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uitdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1156",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Marken",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1161",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwanenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1165",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Halfweg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1171",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Badhoevedorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1175",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lijnden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1181",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amstelveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1182",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amstelveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1183",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amstelveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1184",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amstelveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1185",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amstelveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1186",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amstelveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1187",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amstelveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1188",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amstelveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1189",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amstelveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1191",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ouderkerk aan de Amstel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1211",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilversum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1212",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilversum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1213",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilversum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1214",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilversum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1215",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilversum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1216",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilversum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1217",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilversum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1218",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilversum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1221",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilversum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1222",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilversum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1223",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilversum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1231",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loosdrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1241",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kortenhoef",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1243",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Graveland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1244",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ankeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1251",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Laren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1252",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Laren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1261",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blaricum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1262",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blaricum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1271",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1272",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1273",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1274",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1275",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1276",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1277",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1309",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1311",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1312",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1313",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1314",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1315",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1316",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1317",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1318",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1319",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1321",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1322",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1323",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1324",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1325",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1326",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1327",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1328",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1329",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1331",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1332",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1333",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1334",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1335",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1336",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1338",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1339",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1341",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1343",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1349",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1351",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1352",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1353",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1354",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1355",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1356",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1357",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1358",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1359",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1361",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1362",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1363",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1364",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1381",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weesp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1382",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weesp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1383",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weesp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1384",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weesp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1391",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Abcoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1393",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nigtevecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1394",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nederhorst den Berg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1396",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baambrugge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1398",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Muiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1399",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Muiderberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1401",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bussum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1402",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bussum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1403",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bussum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1404",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bussum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1405",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bussum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1406",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bussum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1411",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Naarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1412",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Naarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1421",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uithoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1422",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uithoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1423",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uithoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1424",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Kwakel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1426",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "de Hoef",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1427",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amstelhoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1428",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vrouwenakker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1431",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aalsmeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1432",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aalsmeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1433",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kudelstaart",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1435",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijsenhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1436",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aalsmeerderbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1437",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rozenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1438",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oude Meer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1441",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Purmerend",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1442",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Purmerend",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1443",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Purmerend",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1444",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Purmerend",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1445",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Purmerend",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1446",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Purmerend",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1447",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Purmerend",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1448",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Purmerend",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1451",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Purmerland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1452",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ilpendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1454",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Watergang",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1456",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijdewormer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1458",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijkerboor",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1461",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidoostbeemster",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1462",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middenbeemster",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1463",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordbeemster",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1464",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westbeemster",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1471",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kwadijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1472",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1473",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1474",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosthuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1475",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beets",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1476",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schardam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1477",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hobrede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1481",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Purmer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1482",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Purmer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1483",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Rijp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1484",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Graft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1485",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordeinde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1486",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "West-Graftdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1487",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oost-Graftdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1488",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Starnmeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1489",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "de Woude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1501",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaandam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1502",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaandam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1503",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaandam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1504",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaandam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1505",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaandam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1506",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaandam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1507",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaandam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1508",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaandam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1509",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaandam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1511",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oostzaan",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1521",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wormerveer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1525",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westknollendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1531",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wormer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1534",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oostknollendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1536",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Markenbinnen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1541",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koog aan de Zaan",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1544",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaandijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1546",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jisp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1551",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westzaan",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1561",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Krommenie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1562",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Krommenie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1566",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Assendelft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1567",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Assendelft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1601",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enkhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1602",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enkhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1606",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1607",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1608",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijdenes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1609",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterleek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1611",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bovenkarspel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1613",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grootebroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1614",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lutjebroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1616",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogkarspel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1617",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westwoud",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1619",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Andijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1621",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1622",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1623",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1624",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1625",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1627",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1628",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1631",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudendijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1633",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Avenhorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1634",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Scharwoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1636",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schermerhorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1641",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spierdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1642",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spierdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1643",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spierdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1645",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ursem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1646",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ursem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1647",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berkhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1648",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Goorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1652",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1654",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Benningbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1655",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sijbekarspel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1657",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Abbekerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1658",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lambertschaag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1661",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Weere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1662",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Weere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1663",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Weere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1671",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Medemblik",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1674",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Opperdoes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1676",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Twisk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1678",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oostwoud",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1679",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Midwoud",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1681",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwaagdijk-Oost",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1682",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwaagdijk-Oost",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1683",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwaagdijk-Oost",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1684",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwaagdijk-Oost",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1685",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwaagdijk-West",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1686",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwaagdijk-West",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1687",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wognum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1688",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nibbixwoud",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1689",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwaag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1691",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hauwert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1692",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hauwert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1693",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wervershoof",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1695",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blokker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1696",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterblokker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1697",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schellinkhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1701",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerhugowaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1702",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerhugowaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1703",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerhugowaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1704",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerhugowaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1705",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerhugowaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1706",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerhugowaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1711",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hensbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1713",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Obdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1715",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spanbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1716",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Opmeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1718",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogwoud",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1719",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aartswoud",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1721",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Broek op Langedijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1722",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuid-Scharwoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1723",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noord-Scharwoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1724",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudkarspel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1731",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winkel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1732",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lutjewinkel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1733",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwe Niedorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1734",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oude Niedorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1735",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'t Veld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1736",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zijdewind",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1738",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waarland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1741",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schagen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1742",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schagen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1744",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Maarten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1746",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dirkshorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1747",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tuitjenhorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1749",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warmenhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1751",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schagerbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1752",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Maartensbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1753",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Maartensvlotbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1754",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Burgerbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1755",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Petten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1756",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'t Zand",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1757",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudesluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1759",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Callantsoog",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1761",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Anna Paulowna",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1764",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breezand",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1766",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wieringerwaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1767",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kolhorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1768",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Barsingerhorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1769",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haringhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1771",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wieringerwerf",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1773",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kreileroord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1774",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Slootdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1775",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middenmeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1777",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hippolytushoef",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1778",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westerland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1779",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Oever",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1781",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Helder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1782",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Helder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1783",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Helder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1784",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Helder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1785",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Helder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1786",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Helder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1787",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Julianadorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1788",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Julianadorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1789",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huisduinen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1791",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Burg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1792",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudeschild",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1793",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Waal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1794",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterend",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1795",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Cocksdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1796",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Koog",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1797",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Hoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1811",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1812",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1813",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1814",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1815",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1816",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1817",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1821",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1822",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1823",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1824",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1825",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1826",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1827",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alkmaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1829",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1831",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koedijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1832",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koedijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1834",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Pancras",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1841",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stompetoren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1842",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oterleek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1843",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grootschermer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1844",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Driehuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1846",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidschermer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1847",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidschermer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1851",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heiloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1852",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heiloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1853",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heiloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1861",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen (NH)",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1862",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen (NH)",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1865",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen aan Zee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1871",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schoorl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1873",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1901",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Castricum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1902",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Castricum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1906",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Limmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1911",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uitgeest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1921",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Akersloot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1931",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Egmond aan Zee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1934",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Egmond aan den Hoef",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1935",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Egmond-Binnen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1941",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beverwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1942",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beverwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1943",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beverwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1944",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beverwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1945",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beverwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1946",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beverwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1947",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beverwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1948",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beverwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1949",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijk aan Zee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1951",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Velsen-Noord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1961",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemskerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1962",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemskerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1963",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemskerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1964",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemskerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1965",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemskerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1966",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemskerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1967",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemskerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1968",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemskerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1969",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemskerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1971",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJmuiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1972",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJmuiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1973",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJmuiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1974",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJmuiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1975",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJmuiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1976",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJmuiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1981",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Velsen-Zuid",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1985",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Driehuis NH",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1991",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Velserbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "1992",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Velserbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2011",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2012",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2013",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2014",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2015",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2019",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2021",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2022",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2023",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2024",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2025",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2026",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2031",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2032",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2033",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2034",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2035",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2036",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2037",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2041",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zandvoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2042",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zandvoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2051",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Overveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2061",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bloemendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2063",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spaarndam gem. Haarlem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2064",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spaarndam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2065",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlemmerliede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2071",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Santpoort-Noord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2082",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Santpoort-Zuid",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2101",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemstede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2102",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemstede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2103",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemstede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2104",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemstede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2105",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemstede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2106",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemstede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2111",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aerdenhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2114",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vogelenzang",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2116",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bentveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2121",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bennebroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2131",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoofddorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2132",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoofddorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2133",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoofddorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2134",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoofddorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2135",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoofddorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2136",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwaanshoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2141",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vijfhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2142",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Cruquius",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2143",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boesingheliede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2144",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beinsdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2151",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Vennep",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2152",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Vennep",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2153",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Vennep",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2154",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Burgerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2155",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leimuiderbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2156",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weteringbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2157",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Abbenes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2158",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Buitenkaag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2159",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kaag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2161",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2162",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2163",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2165",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lisserbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2171",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sassenheim",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2172",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sassenheim",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2181",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hillegom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2182",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hillegom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2191",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Zilk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2201",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2202",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2203",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2204",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2211",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordwijkerhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2212",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordwijkerhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2215",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2216",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2221",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Katwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2222",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Katwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2223",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Katwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2224",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Katwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2225",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Katwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2231",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijnsburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2232",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijnsburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2235",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valkenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2236",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valkenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2241",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wassenaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2242",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wassenaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2243",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wassenaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2244",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wassenaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2245",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wassenaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2251",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorschoten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2252",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorschoten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2253",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorschoten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2254",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorschoten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2261",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leidschendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2262",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leidschendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2263",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leidschendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2264",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leidschendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2265",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leidschendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2266",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leidschendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2267",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leidschendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2271",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2272",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2273",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2274",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2275",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2281",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2282",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2283",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2284",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2285",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2286",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2287",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2288",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2289",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2291",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wateringen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2292",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wateringen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2295",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kwintsheul",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2311",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2312",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2313",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2314",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2315",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2316",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2317",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2318",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2321",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2322",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2323",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2324",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2331",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2332",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2333",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2334",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2341",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oegstgeest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2342",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oegstgeest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2343",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oegstgeest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2351",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiderdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2352",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiderdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2353",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leiderdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2355",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogmade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2361",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2362",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2371",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roelofarendsveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2374",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oud Ade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2375",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijpwetering",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2376",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwe Wetering",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2377",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oude Wetering",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2381",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoeterwoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2382",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoeterwoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2391",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hazerswoude-Dorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2394",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hazerswoude-Rijndijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2396",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koudekerk aan den Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2401",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alphen aan den Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2402",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alphen aan den Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2403",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alphen aan den Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2404",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alphen aan den Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2405",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alphen aan den Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2406",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alphen aan den Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2407",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alphen aan den Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2408",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alphen aan den Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2409",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alphen aan den Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2411",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bodegraven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2412",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bodegraven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2415",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwerbrug aan den Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2421",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwkoop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2431",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noorden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2432",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noorden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2435",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2441",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2445",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aarlanderveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2451",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leimuiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2461",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ter Aar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2465",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijnsaterwoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2471",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwammerdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2481",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woubrugge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2491",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2492",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2493",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2495",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2496",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2497",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2498",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2511",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2512",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2513",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2514",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2515",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2516",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2517",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2518",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2521",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2522",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2523",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2524",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2525",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2526",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2531",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2532",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2533",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2541",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2542",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2543",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2544",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2545",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2546",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2547",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2548",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2551",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2552",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2553",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2554",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2555",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2561",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2562",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2563",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2564",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2565",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2566",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2571",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2572",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2573",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2574",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2581",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2582",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2583",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2584",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2585",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2586",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2587",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2591",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2592",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2593",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2594",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2595",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2596",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2597",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenhage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2611",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2612",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2613",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2614",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2616",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2622",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2623",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2624",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2625",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2626",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2627",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2628",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2629",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2631",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nootdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2632",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nootdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2635",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Hoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2636",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schipluiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2641",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Pijnacker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2642",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Pijnacker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2643",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Pijnacker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2645",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delfgauw",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2651",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berkel en Rodenrijs",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2652",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berkel en Rodenrijs",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2661",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergschenhoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2662",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergschenhoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2665",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bleiswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2671",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Naaldwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2672",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Naaldwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2673",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Naaldwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2675",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Honselersdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2676",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maasdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2678",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Lier",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2681",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Monster",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2684",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ter Heijde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2685",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Poeldijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2691",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenzande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2692",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenzande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2693",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenzande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2694",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenzande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2711",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2712",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2713",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2715",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2716",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2717",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2718",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2719",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2721",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2722",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2723",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2724",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2725",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2726",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2727",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2728",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2729",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoetermeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2731",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Benthuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2735",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gelderswoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2741",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waddinxveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2742",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waddinxveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2743",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waddinxveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2751",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Moerkapelle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2752",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Moerkapelle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2761",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2765",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Cortelande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2771",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boskoop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2801",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gouda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2802",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gouda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2803",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gouda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2804",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gouda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2805",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gouda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2806",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gouda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2807",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gouda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2808",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gouda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2809",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gouda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2811",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Reeuwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2821",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stolwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2825",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berkenwoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2831",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gouderak",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2841",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Moordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2851",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haastrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2855",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlist",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2861",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergambacht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2865",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ammerstol",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2871",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schoonhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2872",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schoonhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2901",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Capelle aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2902",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Capelle aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2903",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Capelle aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2904",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Capelle aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2905",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Capelle aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2906",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Capelle aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2907",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Capelle aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2908",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Capelle aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2909",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Capelle aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2911",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwerkerk aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2912",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwerkerk aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2913",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwerkerk aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2914",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwerkerk aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2921",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Krimpen aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2922",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Krimpen aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2923",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Krimpen aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2924",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Krimpen aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2925",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Krimpen aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2926",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Krimpen aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2931",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Krimpen aan de Lek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2935",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ouderkerk aan den IJssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2941",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lekkerkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2951",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alblasserdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2952",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alblasserdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2953",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alblasserdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2954",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alblasserdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2957",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Lekkerland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2959",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Streefkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2961",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kinderdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2964",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groot-Ammers",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2965",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwpoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2967",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Langerak",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2968",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2969",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oud-Alblas",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2971",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bleskensgraaf ca",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2973",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Molenaarsgraaf",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2974",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brandwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2975",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ottoland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2977",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goudriaan",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2981",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ridderkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2982",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ridderkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2983",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ridderkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2984",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ridderkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2985",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ridderkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2986",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ridderkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2987",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ridderkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2988",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ridderkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2989",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ridderkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2991",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Barendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2992",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Barendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2993",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Barendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2994",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Barendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "2995",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerjansdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3011",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3012",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3013",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3014",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3015",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3016",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3021",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3022",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3023",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3024",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3025",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3026",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3027",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3028",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3029",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3031",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3032",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3033",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3034",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3035",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3036",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3037",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3038",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3039",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3041",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3042",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3043",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3044",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3045",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3046",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3047",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3051",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3052",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3053",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3054",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3055",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3056",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3059",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3061",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3062",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3063",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3064",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3065",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3066",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3067",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3068",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3069",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3071",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3072",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3073",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3074",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3075",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3076",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3077",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3078",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3079",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3081",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3082",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3083",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3084",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3085",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3086",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3087",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3088",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3089",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3111",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3112",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3113",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3114",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3115",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3116",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3117",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3118",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3119",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3121",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3122",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3123",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3124",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3125",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3131",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlaardingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3132",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlaardingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3133",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlaardingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3134",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlaardingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3135",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlaardingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3136",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlaardingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3137",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlaardingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3138",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlaardingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3141",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maassluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3142",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maassluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3143",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maassluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3144",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maassluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3145",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maassluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3146",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maassluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3147",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maassluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3151",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoek van Holland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3155",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maasland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3161",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rhoon",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3162",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rhoon",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3165",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotterdam-Albrandswaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3171",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Poortugaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3172",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Poortugaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3176",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Poortugaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3181",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rozenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3191",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogvliet Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3192",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogvliet Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3193",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogvliet Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3194",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogvliet Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3195",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Pernis Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3196",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vondelingenplaat Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3197",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Botlek Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3198",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Europoort Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3199",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maasvlakte Rotterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3201",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijkenisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3202",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijkenisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3203",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijkenisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3204",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijkenisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3205",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijkenisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3206",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijkenisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3207",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijkenisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3208",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijkenisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3209",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hekelingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3211",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geervliet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3212",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Simonshaven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3214",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3216",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Abbenbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3218",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heenvliet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3221",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hellevoetsluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3222",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hellevoetsluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3223",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hellevoetsluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3224",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hellevoetsluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3225",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hellevoetsluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3227",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudenhoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3231",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brielle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3232",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brielle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3233",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oostvoorne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3234",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tinte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3235",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rockanje",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3237",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vierpolders",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3238",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwartewaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3241",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelharnis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3243",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stad aan 't Haringvliet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3244",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwe-Tonge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3245",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sommelsdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3247",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dirksland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3248",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Melissant",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3249",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Herkingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3251",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stellendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3252",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goedereede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3253",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ouddorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3255",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oude-Tonge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3256",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Achthuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3257",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ooltgensplaat",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3258",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Bommel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3261",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oud-Beijerland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3262",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oud-Beijerland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3263",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oud-Beijerland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3264",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Beijerland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3265",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Piershil",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3267",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goudswaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3271",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mijnsheerenland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3273",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westmaas",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3274",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heinenoord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3281",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Numansdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3284",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuid-Beijerland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3286",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Klaaswaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3291",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Strijen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3292",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Strijensas",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3293",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mookhoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3295",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravendeel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3297",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Puttershoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3299",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maasdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3311",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3312",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3313",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3314",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3315",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3316",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3317",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3318",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3319",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3328",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3329",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3331",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwijndrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3332",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwijndrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3333",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwijndrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3334",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwijndrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3335",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwijndrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3336",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwijndrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3341",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hendrik-Ido-Ambacht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3342",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hendrik-Ido-Ambacht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3343",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hendrik-Ido-Ambacht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3344",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hendrik-Ido-Ambacht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3351",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Papendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3352",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Papendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3353",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Papendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3354",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Papendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3355",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Papendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3356",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Papendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3361",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sliedrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3362",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sliedrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3363",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sliedrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3364",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sliedrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3366",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijngaarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3371",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hardinxveld-Giessendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3372",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hardinxveld-Giessendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3373",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hardinxveld-Giessendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3381",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Giessenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3401",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJsselstein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3402",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJsselstein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3403",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJsselstein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3404",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJsselstein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3405",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Benschop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3411",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lopik",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3412",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lopikerkapel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3413",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jaarsveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3415",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Polsbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3417",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Montfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3421",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudewater",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3425",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Snelrewaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3431",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwegein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3432",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwegein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3433",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwegein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3434",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwegein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3435",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwegein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3436",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwegein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3437",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwegein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3438",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwegein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3439",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwegein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3441",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3442",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3443",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3444",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3445",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3446",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3447",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3448",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3449",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3451",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vleuten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3452",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vleuten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3453",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Meern",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3454",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Meern",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3455",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarzuilens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3461",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Linschoten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3464",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Papekop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3465",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Driebruggen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3466",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waarder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3467",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hekendorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3471",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kamerik",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3474",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zegveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3481",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harmelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3511",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3512",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3513",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3514",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3515",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3521",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3522",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3523",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3524",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3525",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3526",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3527",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3528",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3531",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3532",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3533",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3534",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3541",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3542",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3543",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3544",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3545",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3546",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3551",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3552",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3553",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3554",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3555",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3561",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3562",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3563",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3564",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3565",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3566",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3571",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3572",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3573",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3581",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3582",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3583",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3584",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3585",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Utrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3601",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maarssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3602",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maarssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3603",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maarssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3604",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maarssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3605",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maarssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3606",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maarssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3607",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maarssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3608",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maarssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3611",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oud Zuilen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3612",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tienhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3615",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3621",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breukelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3625",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breukeleveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3626",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwer Ter Aa",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3628",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kockengen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3631",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwersluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3632",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loenen aan de Vecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3633",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vreeland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3634",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loenersloot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3641",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mijdrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3642",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mijdrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3643",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mijdrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3645",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vinkeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3646",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waverveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3648",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wilnis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3651",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerdense Verlaat",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3652",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerdense Verlaat",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3653",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woerdense Verlaat",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3701",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeist",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3702",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeist",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3703",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeist",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3704",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeist",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3705",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeist",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3706",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeist",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3707",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeist",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3708",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeist",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3709",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeist",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3711",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Austerlitz",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3712",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huis ter Heide",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3721",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bilthoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3722",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bilthoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3723",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bilthoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3731",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Bilt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3732",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Bilt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3734",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Dolder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3735",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bosch en Duin",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3737",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groenekan",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3738",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maartensdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3739",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hollandsche Rading",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3741",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baarn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3742",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baarn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3743",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baarn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3744",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baarn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3749",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lage Vuursche",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3751",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bunschoten-Spakenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3752",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bunschoten-Spakenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3754",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eemdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3755",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eemnes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3761",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Soest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3762",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Soest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3763",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Soest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3764",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Soest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3765",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Soest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3766",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Soest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3768",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Soest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3769",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Soesterberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3771",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Barneveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3772",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Barneveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3773",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Barneveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3774",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kootwijkerbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3775",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kootwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3776",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stroe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3781",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorthuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3784",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terschuur",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3785",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwartebroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3791",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Achterveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3792",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Achterveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3794",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Glind",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3811",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3812",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3813",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3814",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3815",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3816",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3817",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3818",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3819",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3821",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3822",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3823",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3824",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3825",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3826",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amersfoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3828",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3829",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hooglanderveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3831",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leusden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3832",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leusden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3833",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leusden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3834",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leusden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3835",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stoutenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3836",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stoutenburg Noord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3841",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harderwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3842",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harderwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3843",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harderwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3844",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harderwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3845",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harderwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3846",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harderwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3847",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harderwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3848",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harderwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3849",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hierden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3851",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ermelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3852",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ermelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3853",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ermelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3861",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3862",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3863",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3864",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijkerkerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3871",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoevelaken",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3881",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Putten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3882",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Putten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3886",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Garderen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3888",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uddel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3891",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeewolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3892",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeewolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3893",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeewolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3894",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeewolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3895",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeewolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3896",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeewolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3897",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeewolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3898",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeewolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3899",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeewolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3901",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veenendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3902",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veenendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3903",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veenendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3904",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veenendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3905",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veenendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3906",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veenendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3907",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veenendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3911",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rhenen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3912",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rhenen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3921",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elst Ut",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3922",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elst Ut",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3925",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Scherpenzeel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3927",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Renswoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3931",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woudenberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3941",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3945",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Cothen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3947",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Langbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3951",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maarn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3953",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maarsbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3956",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leersum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3958",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amerongen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3959",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Overberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3961",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijk bij Duurstede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3962",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijk bij Duurstede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3971",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Driebergen-Rijsenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3972",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Driebergen-Rijsenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3981",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bunnik",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3984",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Odijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3985",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Werkhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3989",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ossenwaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3991",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Houten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3992",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Houten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3993",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Houten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3994",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Houten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3995",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Houten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3997",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'t Goy",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3998",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schalkwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "3999",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tull en 't Waal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4001",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tiel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4002",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tiel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4003",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tiel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4004",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tiel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4005",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tiel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4006",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tiel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4007",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tiel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4011",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4012",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerk-Avezaath",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4013",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kapel Avezaath",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4014",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wadenoijen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4016",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kapel-Avezaath",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4017",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerk Avezaath",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4021",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maurik",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4023",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijswijk (GLD)",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4024",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eck en Wiel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4031",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4032",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ommeren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4033",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lienden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4041",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kesteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4043",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Opheusden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4051",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ochten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4053",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJzendoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4054",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Echteld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4061",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ophemert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4062",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zennewijnen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4063",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heesselt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4064",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Varik",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4101",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Culemborg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4102",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Culemborg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4103",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Culemborg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4104",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Culemborg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4105",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Culemborg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4106",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Culemborg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4107",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Culemborg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4111",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoelmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4112",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beusichem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4115",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Asch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4116",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Buren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4117",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Erichem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4119",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ravenswaaij",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4121",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Everdingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4122",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zijderveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4124",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hagestein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4125",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoef en Haag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4126",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hei- en Boeicop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4128",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lexmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4131",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vianen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4132",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vianen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4133",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vianen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4141",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leerdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4142",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leerdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4143",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leerdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4145",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schoonrewoerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4147",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Asperen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4151",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Acquoy",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4152",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rhenoy",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4153",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beesd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4155",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gellicum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4156",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rumpt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4157",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enspijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4158",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deil",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4161",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heukelum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4163",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4171",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Herwijnen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4174",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hellouw",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4175",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haaften",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4176",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tuil",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4181",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waardenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4182",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Neerijnen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4184",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Opijnen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4185",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Est",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4191",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geldermalsen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4194",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4196",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4197",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Buurmalsen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4201",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gorinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4202",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gorinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4203",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gorinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4204",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gorinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4205",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gorinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4206",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gorinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4207",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gorinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4208",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gorinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4209",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schelluinen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4211",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4212",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4213",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dalem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4214",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vuren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4221",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogblokland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4223",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoornaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4225",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordeloos",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4231",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meerkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4233",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ameide",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4235",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tienhoven aan de Lek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4241",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arkel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4243",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4245",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leerbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4247",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kedichem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4251",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Werkendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4254",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sleeuwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4255",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwendijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4261",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijk en Aalburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4264",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4265",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Genderen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4266",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eethen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4267",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drongelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4268",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meeuwen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4269",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Babyloniënbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4271",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dussen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4273",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hank",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4281",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Andel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4283",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Giessen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4284",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijswijk (NB)",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4285",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woudrichem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4286",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4287",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waardhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4288",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uitwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4301",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zierikzee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4302",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zierikzee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4303",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zierikzee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4305",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ouwerkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4306",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwerkerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4307",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4308",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sirjansland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4311",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bruinisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4315",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dreischor",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4316",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zonnemaire",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4317",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordgouwe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4318",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brouwershaven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4321",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkwerve",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4322",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Scharendijke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4323",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ellemeet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4325",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Renesse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4326",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordwelle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4327",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Serooskerke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4328",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Burgh-Haamstede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4331",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4332",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4333",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4334",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4335",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4336",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4337",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4338",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4339",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw- en Sint Joosland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4341",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnemuiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4351",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veere",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4352",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gapinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4353",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Serooskerke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4354",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vrouwenpolder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4356",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oostkapelle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4357",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Domburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4361",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westkapelle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4363",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aagtekerke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4364",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grijpskerke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4365",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meliskerke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4371",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koudekerke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4373",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Biggekerke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4374",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoutelande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4381",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlissingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4382",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlissingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4383",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlissingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4384",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlissingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4385",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlissingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4386",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlissingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4387",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlissingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4388",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oost-Souburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4389",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ritthem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4401",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Yerseke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4411",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rilland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4413",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Krabbendijke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4414",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waarde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4415",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oostdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4416",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kruiningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4417",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hansweert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4421",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kapelle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4423",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schore",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4424",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wemeldinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4431",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Gravenpolder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4433",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoedekenskerke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4434",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kwadendamme",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4435",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baarland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4436",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudelande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4437",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ellewoutsdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4438",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Driewegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4441",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ovezande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4443",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4444",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Heer Abtskerke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4451",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heinkenszand",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4453",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Heerenhoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4454",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Borssele",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4455",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4456",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lewedorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4458",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Heer Arendskerke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4461",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4462",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4463",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4464",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4465",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4471",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wolphaartsdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4472",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Heer Hendrikskinderen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4474",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kattendijke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4475",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wilhelminadorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4481",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kloetinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4482",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kloetinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4484",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kortgene",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4485",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kats",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4486",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Colijnsplaat",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4491",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wissenkerke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4493",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kamperland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4494",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geersdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4501",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oostburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4503",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4504",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwvliet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4505",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidzande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4506",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Cadzand",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4507",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schoondijke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4508",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waterlandkerkje",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4511",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breskens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4513",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoofdplaat",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4515",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJzendijke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4521",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Biervliet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4522",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Biervliet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4524",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4525",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Retranchement",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4527",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aardenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4528",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Kruis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4529",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4531",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terneuzen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4532",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terneuzen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4533",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terneuzen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4535",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terneuzen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4536",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terneuzen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4537",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terneuzen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4538",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terneuzen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4539",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spui",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4541",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sluiskil",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4542",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4543",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaamslag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4551",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sas van Gent",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4553",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Philippine",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4554",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westdorpe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4561",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hulst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4562",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hulst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4564",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Jansteen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4565",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kapellebrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4566",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heikant",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4567",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Clinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4568",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw Namen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4569",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Graauw",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4571",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Axel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4574",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuiddorpe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4575",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Overslag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4576",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koewacht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4581",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vogelwaarde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4583",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terhole",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4584",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kuitaart",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4585",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengstdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4586",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lamswaarde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4587",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kloosterzande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4588",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Walsoorden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4589",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ossenisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4611",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4612",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4613",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4614",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4615",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4616",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4617",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4621",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4622",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4623",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4624",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4625",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen op Zoom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4631",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogerheide",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4634",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woensdrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4635",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huijbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4641",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ossendrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4645",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Putte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4651",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steenbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4652",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steenbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4655",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Heen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4661",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Halsteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4664",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lepelstraat",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4671",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dinteloord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4675",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Philipsland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4681",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Vossemeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4691",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tholen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4693",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Poortvliet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4694",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Scherpenisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4695",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint-Maartensdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4696",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stavenisse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4697",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint-Annaland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4698",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oud-Vossemeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4701",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roosendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4702",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roosendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4703",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roosendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4704",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roosendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4705",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roosendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4706",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roosendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4707",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roosendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4708",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roosendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4709",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nispen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4711",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "St. Willebrord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4714",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sprundel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4715",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rucphen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4721",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schijf",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4722",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schijf",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4724",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wouw",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4725",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wouwse Plantage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4726",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4727",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Moerstraten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4731",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4735",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zegge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4741",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoeven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4744",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bosschenhoofd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4751",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oud Gastel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4754",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stampersgat",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4756",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kruisland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4758",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Standdaarbuiten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4759",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordhoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4761",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4762",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4765",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenbergschen Hoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4766",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenbergschen Hoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4771",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Langeweg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4772",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Langeweg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4781",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Moerdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4782",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Moerdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4791",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Klundert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4793",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Fijnaart",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4794",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heijningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4796",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudemolen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4797",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Willemstad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4811",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4812",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4813",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4814",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4815",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4816",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4817",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4818",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4819",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4822",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4823",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4824",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4825",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4826",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4827",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4834",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4835",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4836",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4837",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4838",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4839",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4841",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Prinsenbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4844",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terheijden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4845",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wagenberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4847",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Teteringen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4849",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4851",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ulvenhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4854",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bavel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4855",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Galder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4856",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Strijbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4858",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ulvenhout AC",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4859",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bavel AC",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4861",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Chaam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4871",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Etten-Leur",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4872",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Etten-Leur",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4873",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Etten-Leur",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4874",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Etten-Leur",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4875",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Etten-Leur",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4876",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Etten-Leur",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4877",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Etten-Leur",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4878",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Etten-Leur",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4879",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Etten-Leur",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4881",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zundert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4882",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Klein Zundert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4884",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wernhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4885",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Achtmaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4891",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijsbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4901",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4902",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4903",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4904",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4905",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4906",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4907",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4908",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4909",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosteind",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4911",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Hout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4921",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Made",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4924",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drimmelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4926",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lage Zwaluwe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4927",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hooge Zwaluwe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4931",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geertruidenberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4941",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Raamsdonksveer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4942",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Raamsdonksveer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "4944",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Raamsdonk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5011",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5012",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5013",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5014",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5015",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5017",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5018",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5021",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5022",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5025",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5026",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5032",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5035",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5036",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5037",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5038",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5041",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5042",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5043",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5044",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5045",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5046",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5047",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5048",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5049",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5051",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goirle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5052",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goirle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5053",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goirle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5056",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berkel-Enschot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5057",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berkel-Enschot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5059",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heukelom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5061",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oisterwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5062",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oisterwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5063",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oisterwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5066",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Moergestel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5071",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Udenhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5074",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Biezenmortel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5076",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haaren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5081",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilvarenbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5084",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Biest-Houtakker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5085",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Esbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5087",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Diessen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5089",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haghorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5091",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oost West en Middelbeers",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5094",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lage Mierde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5095",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hooge Mierde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5096",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hulsel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5101",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dongen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5102",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dongen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5103",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dongen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5104",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dongen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5105",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dongen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5106",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dongen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5107",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dongen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5109",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s Gravenmoer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5111",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baarle-Nassau",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5113",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ulicoten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5114",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Castelre",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5121",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5122",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5124",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Molenschot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5125",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hulten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5126",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gilze",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5131",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alphen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5133",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Riel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5141",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waalwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5142",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waalwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5143",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waalwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5144",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waalwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5145",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waalwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5146",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waalwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5151",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drunen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5152",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drunen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5154",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elshout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5156",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudheusden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5157",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doeveren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5158",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heesbeen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5161",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sprang-Capelle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5165",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waspik",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5171",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kaatsheuvel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5172",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kaatsheuvel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5175",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loon op Zand",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5176",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Moer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5211",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5212",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5213",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5215",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5216",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5221",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5222",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5223",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5224",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5231",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5232",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5233",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5234",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5235",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5236",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5237",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Hertogenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5241",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rosmalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5242",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rosmalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5243",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rosmalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5244",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rosmalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5245",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rosmalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5246",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rosmalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5247",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rosmalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5248",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rosmalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5249",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rosmalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5251",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlijmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5252",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlijmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5253",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwkuijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5254",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarsteeg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5255",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Herpt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5256",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heusden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5257",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hedikhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5258",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berlicum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5261",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vught",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5262",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vught",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5263",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vught",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5264",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vught",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5266",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Cromvoirt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5268",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helvoirt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5271",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint-Michielsgestel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5272",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint-Michielsgestel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5275",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Dungen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5281",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boxtel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5282",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boxtel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5283",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boxtel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5291",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gemonde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5292",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gemonde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5293",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gemonde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5294",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gemonde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5296",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Esch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5298",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Liempde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5301",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaltbommel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5302",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zaltbommel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5305",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuilichem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5306",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brakel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5307",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Poederoijen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5308",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aalst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5311",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gameren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5313",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5314",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bruchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5315",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5316",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delwijnen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5317",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nederhemert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5318",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bern",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5321",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hedel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5324",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ammerzoden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5325",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Well",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5327",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hurwenen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5328",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rossum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5331",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkdriel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5333",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoenzadriel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5334",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Velddriel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5335",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5341",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oss",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5342",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oss",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5343",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oss",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5344",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oss",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5345",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oss",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5346",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oss",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5347",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oss",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5348",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oss",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5349",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oss",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5351",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berghem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5352",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deursen-Dennenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5353",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dieden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5354",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Demen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5355",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Neerlangel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5356",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Neerloon",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5357",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Overlangel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5358",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huisseling",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5359",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Keent",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5361",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grave",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5363",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Velp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5364",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Escharen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5366",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Megen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5367",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Macharen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5368",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5371",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ravenstein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5373",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Herpen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5374",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schaijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5375",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Reek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5381",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vinkel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5382",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vinkel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5383",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vinkel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5384",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heesch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5386",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geffen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5388",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nistelrode",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5391",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nuland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5392",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nuland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5394",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oijen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5395",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Teeffelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5396",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lithoijen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5397",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lith",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5398",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maren-Kessel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5401",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5402",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5403",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5404",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5405",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5406",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5408",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Volkel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5409",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Odiliapeel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5411",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeeland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5421",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gemert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5422",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gemert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5423",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Handel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5424",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elsendorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5425",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Mortel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5427",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boekel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5428",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venhorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5431",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Cuijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5432",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Cuijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5433",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Katwijk NB",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5434",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vianen NB",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5435",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Agatha",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5437",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beers NB",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5438",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gassel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5439",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Linden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5441",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oeffelt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5443",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haps",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5445",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Landhorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5446",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wanroij",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5447",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijkevoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5449",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijkevoort-De Walsert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5451",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mill",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5453",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Langenboom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5454",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Hubert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5455",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wilbertoord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5461",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veghel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5462",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veghel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5463",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veghel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5464",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veghel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5465",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veghel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5466",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veghel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5467",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veghel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5469",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Erp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5471",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loosbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5472",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loosbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5473",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heeswijk-Dinther",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5476",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vorstenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5481",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schijndel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5482",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schijndel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5491",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint-Oedenrode",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5492",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint-Oedenrode",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5501",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veldhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5502",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veldhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5503",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veldhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5504",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veldhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5505",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veldhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5506",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veldhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5507",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veldhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5508",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veldhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5509",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veldhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5511",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Knegsel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5512",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vessem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5513",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wintelre",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5521",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eersel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5524",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steensel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5525",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Duizel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5527",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hapert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5528",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogeloon",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5529",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Casteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5531",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bladel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5534",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Netersel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5541",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Reusel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5551",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valkenswaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5552",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valkenswaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5553",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valkenswaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5554",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valkenswaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5555",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valkenswaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5556",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valkenswaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5561",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Riethoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5563",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westerhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5571",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergeijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5575",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Luyksgestel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5581",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waalre",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5582",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waalre",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5583",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waalre",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5591",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heeze",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5595",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leende",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5611",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5612",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5613",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5614",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5615",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5616",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5617",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5621",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5622",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5623",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5624",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5625",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5626",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5627",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5628",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5629",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5631",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5632",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5633",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5641",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5642",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5643",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5644",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5645",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5646",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5647",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5651",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5652",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5653",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5654",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5655",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5656",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5657",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5658",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eindhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5661",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geldrop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5662",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geldrop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5663",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geldrop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5664",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geldrop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5665",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geldrop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5666",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geldrop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5667",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geldrop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5671",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nuenen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5672",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nuenen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5673",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nuenen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5674",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nuenen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5681",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Best",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5682",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Best",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5683",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Best",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5684",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Best",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5685",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Best",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5688",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oirschot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5689",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oirschot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5691",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Son en Breugel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5692",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Son en Breugel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5694",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Son en Breugel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5701",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5702",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5703",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5704",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5705",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5706",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5707",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5708",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5709",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5711",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Someren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5712",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Someren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5715",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lierop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5721",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Asten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5722",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Asten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5724",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ommel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5725",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heusden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5731",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mierlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5735",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aarle-Rixtel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5737",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lieshout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5738",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mariahout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5741",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beek en Donk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5751",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deurne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5752",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deurne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5753",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deurne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5754",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deurne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5756",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlierden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5757",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Liessel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5758",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Neerkant",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5759",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helenaveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5761",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bakel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5763",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Milheeze",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5764",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Rips",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5766",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Griendtsveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5768",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meijel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5801",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venray",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5802",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venray",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5803",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venray",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5804",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venray",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5807",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oostrum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5808",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oirlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5809",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leunen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5811",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Castenray",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5812",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heide",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5813",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ysselsteyn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5814",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veulen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5815",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Merselo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5816",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vredepeel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5817",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Smakt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5821",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vierlingsbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5823",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maashees",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5824",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Holthees",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5825",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Overloon",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5826",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groeningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5827",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vortum-Mullem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5831",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boxmeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5835",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beugen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5836",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sambeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5841",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oploo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5843",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westerbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5844",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stevensbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5845",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Anthonis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5846",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ledeacker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5851",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Afferden L",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5853",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Siebengewald",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5854",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergen L",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5855",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Well L",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5856",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wellerlooi",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5861",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wanssum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5862",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geijsteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5863",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blitterswijck",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5864",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meerlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5865",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tienray",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5866",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Swolgen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5871",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Broekhuizenvorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5872",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Broekhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5911",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5912",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5913",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5914",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5915",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5916",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5921",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5922",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5923",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5924",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5925",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5926",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5927",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5928",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5931",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tegelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5932",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tegelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5935",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steyl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5941",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Velden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5943",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lomm",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5944",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arcen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5951",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Belfeld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5953",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Reuver",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5954",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beesel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5961",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Horst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5962",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Melderslo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5963",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hegelsom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5964",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meterik",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5966",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "America",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5971",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grubbenvorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5973",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lottum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5975",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sevenum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5976",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kronenberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5977",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Evertsoord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5981",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Panningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5984",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koningslust",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5985",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grashoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5986",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beringe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5987",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Egchel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5988",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Helden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5991",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baarlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5993",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maasbree",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "5995",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kessel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6001",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6002",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6003",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6004",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6005",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6006",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6011",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ell",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6012",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haler",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6013",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hunsel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6014",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ittervoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6015",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Neeritter",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6017",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Thorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6019",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wessem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6021",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Budel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6023",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Budel-Schoot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6024",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Budel-Dorplein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6026",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maarheeze",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6027",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Soerendonk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6028",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gastel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6029",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sterksel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6031",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nederweert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6034",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nederweert-Eind",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6035",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ospel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6037",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kelpen-Oler",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6039",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stramproy",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6041",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roermond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6042",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roermond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6043",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roermond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6044",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roermond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6045",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roermond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6049",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Herten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6051",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maasbracht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6061",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Posterholt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6063",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlodrop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6065",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Montfort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6067",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Linne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6071",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Swalmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6074",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Melick",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6075",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Herkenbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6077",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Odiliënberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6081",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6082",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Buggenum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6083",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nunhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6085",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Horn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6086",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Neer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6088",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roggel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6089",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heibloem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6091",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leveroy",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6092",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leveroy",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6093",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heythuysen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6095",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baexem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6096",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grathem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6097",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6099",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beegden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6101",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Echt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6102",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Echt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6104",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koningsbosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6105",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maria Hoop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6107",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stevensweert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6109",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ohé en Laak",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6111",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Joost",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6112",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Joost",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6114",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Susteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6116",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roosteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6118",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwstadt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6121",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Born",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6122",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Buchten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6123",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Holtum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6124",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Papenhoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6125",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Obbicht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6127",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grevenbicht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6129",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Urmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6131",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sittard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6132",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sittard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6133",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sittard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6134",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sittard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6135",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sittard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6136",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sittard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6137",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sittard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6141",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Limbricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6142",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Einighausen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6143",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Guttecoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6151",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Munstergeleen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6153",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Windraak",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6155",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Puth",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6161",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geleen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6162",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geleen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6163",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geleen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6164",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geleen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6165",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geleen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6166",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geleen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6167",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geleen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6171",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6174",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sweikhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6176",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spaubeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6181",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elsloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6191",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6199",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht-Airport",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6211",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6212",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6213",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6214",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6215",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6216",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6217",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6218",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6219",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6221",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6222",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6223",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6224",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6225",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6226",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6227",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6228",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6229",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maastricht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6231",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meerssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6235",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ulestraten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6237",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Moorveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6241",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bunde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6243",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geulle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6245",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eijsden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6247",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gronsveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6251",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eckelrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6252",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eckelrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6255",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noorbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6261",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mheer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6262",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Banholt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6265",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Geertruid",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6267",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Cadier en Keer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6268",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bemelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6269",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Margraten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6271",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gulpen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6273",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ingber",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6274",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Reijmerstok",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6276",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heijenrath",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6277",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Slenaken",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6278",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beutenaken",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6281",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mechelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6285",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Epen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6286",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wittem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6287",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eys",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6289",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elkenrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6291",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vaals",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6294",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vijlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6295",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lemiers",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6301",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valkenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6305",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schin op Geul",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6307",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Scheulder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6311",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ransdaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6312",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ransdaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6321",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijlre",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6325",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berg en Terblijt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6333",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schimmert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6336",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hulsberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6341",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Walem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6342",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Walem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6343",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Klimmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6351",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bocholtz",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6353",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baneheide",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6361",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nuth",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6363",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijnandsrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6365",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schinnen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6367",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voerendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6369",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Simpelveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6371",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Landgraaf",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6372",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Landgraaf",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6373",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Landgraaf",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6374",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Landgraaf",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6411",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6412",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6413",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6414",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6415",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6416",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6417",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6418",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6419",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6421",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6422",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerlen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6431",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoensbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6432",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoensbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6433",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoensbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6436",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amstenrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6438",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oirsbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6439",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doenrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6441",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brunssum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6442",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brunssum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6443",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brunssum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6444",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brunssum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6445",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brunssum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6446",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brunssum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6447",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Merkelbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6451",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schinveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6454",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jabeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6456",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bingelrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6461",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6462",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6463",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6464",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6465",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6466",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6467",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6468",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6469",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkrade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6471",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eygelshoven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6511",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6512",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6515",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6521",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6522",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6523",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6524",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6525",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6531",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6532",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6533",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6534",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6535",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6536",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6537",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6538",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6541",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6542",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6543",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6544",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6545",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6546",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijmegen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6551",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weurt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6561",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groesbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6562",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groesbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6564",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heilig Landstichting",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6566",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Millingen aan de Rijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6571",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berg en Dal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6572",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berg en Dal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6573",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6574",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ubbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6575",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Persingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6576",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ooij",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6577",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Erlecom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6578",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leuth",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6579",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kekerdom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6581",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Malden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6582",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heumen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6584",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Molenhoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6585",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mook",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6586",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Plasmolen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6587",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6591",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gennep",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6595",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ottersum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6596",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Milsbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6598",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heijen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6599",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ven-Zelderheide",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6601",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijchen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6602",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijchen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6603",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijchen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6604",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijchen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6605",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijchen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6606",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Niftrik",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6611",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Overasselt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6612",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nederasselt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6613",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Balgoij",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6615",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leur",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6616",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hernen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6617",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergharen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6621",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dreumel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6624",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerewaarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6626",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alphen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6627",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Maasbommel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6628",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Altforst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6629",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Appeltern",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6631",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Horssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6634",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Batenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6641",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beuningen Gld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6642",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beuningen Gld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6644",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ewijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6645",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6651",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Druten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6652",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Druten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6653",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6654",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Afferden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6655",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Puiflijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6657",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boven-Leeuwen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6658",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beneden-Leeuwen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6659",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wamel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6661",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6662",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6663",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lent",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6665",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Driel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6666",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6668",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Randwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6669",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dodewaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6671",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zetten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6672",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hemmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6673",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Andelst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6674",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Herveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6675",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6676",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Homoet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6677",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Slijk-Ewijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6678",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterhout",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6681",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bemmel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6684",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ressen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6685",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haalderen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6686",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doornenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6687",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Angeren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6691",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gendt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6701",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wageningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6702",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wageningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6703",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wageningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6704",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wageningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6705",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wageningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6706",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wageningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6707",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wageningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6708",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wageningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6709",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wageningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6711",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6712",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6713",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6714",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6715",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6716",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6717",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6718",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6721",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bennekom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6731",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Otterlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6732",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harskamp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6733",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wekerom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6741",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lunteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6744",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ederveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6745",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Klomp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6811",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6812",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6813",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6814",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6815",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6816",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6821",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6822",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6823",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6824",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6825",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6826",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6827",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6828",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6831",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6832",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6833",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6834",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6835",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6836",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6841",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6842",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6843",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6844",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6845",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6846",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arnhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6851",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huissen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6852",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huissen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6861",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6862",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6865",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doorwerth",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6866",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heelsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6869",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heveadorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6871",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Renkum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6874",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wolfheze",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6877",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6881",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Velp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6882",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Velp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6883",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Velp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6891",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rozendaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6901",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6902",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6903",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6904",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6905",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6909",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Babberich",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6911",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Pannerden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6913",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aerdt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6914",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Herwen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6915",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lobith",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6916",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tolkamer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6917",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6921",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Duiven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6922",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Duiven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6923",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groessen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6924",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loo Gld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6931",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westervoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6932",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westervoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6941",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Didam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6942",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Didam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6951",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dieren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6952",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dieren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6953",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dieren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6955",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ellecom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6956",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spankeren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6957",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Laag-Soeren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6961",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eerbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6964",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hall",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6971",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brummen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6974",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leuvenheim",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6975",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tonden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6981",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doesburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6982",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doesburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6983",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doesburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6984",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doesburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6986",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Angerlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6987",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Giesbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6988",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lathum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6991",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rheden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6994",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Steeg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6996",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drempt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6997",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoog-Keppel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6998",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Laag-Keppel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "6999",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hummelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7001",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doetinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7002",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doetinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7003",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doetinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7004",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doetinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7005",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doetinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7006",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doetinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7007",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doetinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7008",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doetinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7009",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doetinchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7011",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gaanderen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7021",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zelhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7025",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Halle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7031",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wehl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7035",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kilder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7036",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loerbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7037",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7038",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeddam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7039",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stokkum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7041",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Heerenberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7044",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lengel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7045",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Azewijn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7046",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vethuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7047",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Braamt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7048",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijnbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7051",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Varsseveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7054",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westendorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7055",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heelweg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7061",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terborg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7064",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Silvolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7065",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sinderen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7071",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ulft",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7075",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Etten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7076",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Varsselder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7077",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Netterden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7078",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Megchelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7081",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gendringen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7083",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7084",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breedenbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7091",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dinxperlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7095",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Heurne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7101",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7102",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7103",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7104",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk Meddo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7105",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk Huppel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7106",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk Ratum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7107",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk Kotten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7108",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk Woold",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7109",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk Miste",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7113",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk Henxel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7115",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk Brinkheurne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7119",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winterswijk Corle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7121",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aalten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7122",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aalten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7123",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aalten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7126",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bredevoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7131",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lichtenvoorde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7132",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lichtenvoorde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7134",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vragender",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7135",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harreveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7136",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zieuwent",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7137",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lievelde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7141",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groenlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7142",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groenlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7151",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eibergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7152",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eibergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7156",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beltrum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7157",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rekken",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7161",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Neede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7165",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rietmolen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7201",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zutphen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7202",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zutphen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7203",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zutphen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7204",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zutphen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7205",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zutphen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7206",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zutphen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7207",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zutphen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7211",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eefde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7213",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gorssel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7214",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Epse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7215",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Joppe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7216",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kring van Dorth",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7217",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harfsen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7218",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7221",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steenderen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7223",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baak",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7224",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rha",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7225",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Olburgen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7226",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bronkhorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7227",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Toldijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7231",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warnsveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7232",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warnsveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7233",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vierakker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7234",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wichmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7241",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lochem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7242",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lochem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7244",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Barchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7245",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Laren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7251",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vorden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7255",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengelo (Gld)",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7256",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Keijenborg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7261",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ruurlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7263",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mariënvelde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7271",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Borculo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7273",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7274",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geesteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7275",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gelselaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7311",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7312",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7313",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7314",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7315",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7316",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7317",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7321",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7322",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7323",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7324",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7325",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7326",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7327",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7328",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7329",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7331",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7332",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7333",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7334",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7335",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7336",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Apeldoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7339",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ugchelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7341",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beemte Broekland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7345",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wenum Wiesel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7346",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoog Soeren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7348",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Radio Kootwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7351",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoenderloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7352",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoenderloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7361",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beekbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7364",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lieren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7371",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loenen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7381",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Klarenbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7382",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Klarenbeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7383",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Voorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7384",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wilp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7391",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Twello",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7392",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Twello",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7395",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Teuge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7396",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7397",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7399",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Empe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7411",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7412",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7413",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7414",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7415",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7416",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7417",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7418",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7419",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7421",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7422",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7423",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7424",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7425",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7426",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7427",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7428",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deventer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7429",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Colmschate",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7431",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Diepenveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7433",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schalkhaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7434",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lettele",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7435",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Okkenbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7437",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bathmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7439",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steenenkamer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7441",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijverdal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7442",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijverdal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7443",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijverdal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7447",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hellendoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7448",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7451",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Holten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7461",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7462",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7463",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijssen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7466",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuna",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7467",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Notter",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7468",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enter",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7471",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goor",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7472",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goor",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7475",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Markelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7478",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Diepenheim",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7481",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haaksbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7482",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haaksbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7483",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haaksbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7491",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7495",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ambt Delden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7496",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengevelde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7497",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bentelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7511",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7512",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7513",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7514",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7521",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7522",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7523",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7524",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7525",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7531",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7532",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7533",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7534",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7535",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7536",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7541",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7542",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7543",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7544",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7545",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7546",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7547",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7548",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enschede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7551",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7552",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7553",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7554",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7555",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7556",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7557",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7558",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7559",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hengelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7561",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deurningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7562",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deurningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7571",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldenzaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7572",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldenzaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7573",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldenzaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7574",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldenzaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7575",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldenzaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7576",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldenzaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7577",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldenzaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7581",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Losser",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7582",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Losser",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7585",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Glane",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7586",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Overdinkel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7587",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "de Lutte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7588",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beuningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7591",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Denekamp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7595",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weerselo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7596",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rossum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7597",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Saasveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7601",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7602",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7603",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7604",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7605",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7606",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7607",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7608",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7609",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7610",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Almelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7611",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aadorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7614",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mariaparochie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7615",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harbrinkhoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7621",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Borne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7622",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Borne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7623",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Borne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7625",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zenderen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7626",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hertme",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7627",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bornerbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7631",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ootmarsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7634",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tilligte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7635",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lattrop-Breklenkamp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7636",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Agelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7637",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oud Ootmarsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7638",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nutter",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7641",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wierden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7642",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wierden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7645",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoge Hexel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7651",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tubbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7661",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vasse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7662",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hezingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7663",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mander",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7664",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Manderveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7665",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Albergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7666",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Fleringen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7667",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Reutum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7668",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haarle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7671",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vriezenveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7672",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vriezenveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7675",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bruinehaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7676",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westerhaar-Vriezenveensewijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7678",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geesteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7679",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Langeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7681",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vroomshoop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7683",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Ham",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7685",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beerzerveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7686",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geerdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7687",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Daarlerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7688",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Daarle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7691",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bergentheim",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7692",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mariënberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7693",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sibculo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7694",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kloosterhaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7695",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bruchterveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7696",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brucht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7701",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dedemsvaart",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7702",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dedemsvaart",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7705",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drogteropslagen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7707",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Balkbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7711",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwleusen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7715",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Punthorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7721",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dalfsen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7722",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dalfsen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7731",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ommen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7732",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ommen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7734",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vilsteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7735",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arriën",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7736",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beerze",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7737",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stegeren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7738",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Witharen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7739",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vinkenbuurt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7741",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Coevorden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7742",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Coevorden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7751",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7753",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dalerpeel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7754",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wachtum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7755",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dalerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7756",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stieltjeskanaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7761",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schoonebeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7764",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zandpol",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7765",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weiteveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7766",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Schoonebeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7771",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hardenberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7772",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hardenberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7773",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hardenberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7775",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lutten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7776",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Slagharen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7777",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schuinesloot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7778",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loozen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7779",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Holthone",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7781",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Krim",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7782",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Krim",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7783",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gramsbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7784",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ane",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7785",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Anevelde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7786",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Velde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7787",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Holtheme",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7788",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Anerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7791",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Radewijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7792",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Venebrugge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7793",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogenweg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7794",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rheeze",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7795",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Diffelen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7796",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heemserveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7797",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rheezerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7798",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Collendoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7811",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7812",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7813",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7814",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7815",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7821",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7822",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7823",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7824",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7825",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7826",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7827",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7828",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7831",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Weerdinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7833",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Amsterdam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7841",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sleen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7842",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Diphoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7843",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Erm",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7844",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veenoord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7845",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Holsloot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7846",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noord-Sleen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7847",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'t Haantje",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7848",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schoonoord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7849",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Kiel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7851",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zweeloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7852",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wezup",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7853",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wezuperbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7854",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aalden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7855",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meppen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7856",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Benneveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7858",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eeserveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7859",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eeserveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7861",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterhesselen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7863",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gees",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7864",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwinderen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7871",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Klijndijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7872",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valthe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7873",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Odoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7874",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Odoornerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7875",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Exloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7876",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Valthermond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7877",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "2e Valthermond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7881",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmer-Compascuum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7884",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Barger-Compascuum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7885",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Dordrecht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7887",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Erica",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7889",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Klazienaveen-Noord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7891",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Klazienaveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7892",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Klazienaveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7894",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwartemeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7895",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roswinkel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7901",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7902",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7903",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7904",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7905",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7906",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7907",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7908",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7909",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7910",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuweroord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7911",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuweroord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7912",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuweroord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7913",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hollandscheveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7914",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordscheschut",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7915",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alteveer gem Hoogeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7916",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elim",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7917",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geesbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7918",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwlande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7921",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7924",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veeningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7925",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Linde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7926",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kerkenveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7927",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alteveer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7928",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stuifzand",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7929",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwlande Coevorden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7931",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Fluitenberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7932",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Echten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7933",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Pesse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7934",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stuifzand",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7935",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eursinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7936",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tiendeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7937",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tiendeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7938",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Balinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7941",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meppel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7942",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meppel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7943",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meppel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7944",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meppel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7946",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wanneperveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7948",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7949",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rogat",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7951",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Staphorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7954",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rouveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7955",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJhorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7957",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "de Wijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7958",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koekange",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7961",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ruinerwold",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7963",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ruinen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7964",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ansen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7965",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Broekhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7966",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Schiphorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7971",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Havelte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7973",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Darp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7974",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Havelterberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7975",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uffelte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7981",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Diever",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7983",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wapse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7984",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dieverbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7985",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geeuwenbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7986",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wittelte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "7991",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dwingeloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8011",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8012",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8013",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8014",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8015",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8016",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8017",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8019",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8021",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8022",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8023",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8024",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8025",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8026",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8028",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8031",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8032",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8033",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8034",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8035",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8041",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8042",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8043",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8044",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8045",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwolle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8051",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hattem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8052",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hattem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8055",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Laag Zuthem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8061",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hasselt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8064",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwartsluis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8066",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Belt-Schutsloot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8071",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nunspeet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8072",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nunspeet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8075",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elspeet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8076",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vierhouten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8077",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hulshorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8079",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordeinde Gld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8081",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8082",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8084",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'t Harde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8085",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doornspijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8091",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wezep",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8094",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hattemerbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8095",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'t Loo Oldebroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8096",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldebroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8097",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterwolde Gld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8101",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Raalte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8102",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Raalte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8103",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Raalte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8105",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Luttenberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8106",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mariënheem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8107",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Broekland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8111",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heeten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8112",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw Heeten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8121",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Olst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8124",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wesepe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8131",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijhe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8141",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heino",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8144",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lierderholthuis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8146",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dalmsholte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8147",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Giethmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8148",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lemele",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8151",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lemelerveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8152",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lemelerveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8153",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lemelerveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8154",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lemelerveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8161",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Epe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8162",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Epe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8166",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8167",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oene",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8171",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vaassen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8172",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vaassen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8181",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8191",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wapenveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8193",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vorchten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8194",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veessen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8196",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Welsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8198",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Marle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8211",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8212",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8218",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8219",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8221",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8222",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8223",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8224",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8225",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8226",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8231",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8232",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8233",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8239",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8241",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8242",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8243",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8244",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8245",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lelystad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8251",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dronten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8252",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dronten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8253",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dronten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8254",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dronten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8255",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Swifterbant",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8256",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Biddinghuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8261",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kampen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8262",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kampen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8263",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kampen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8264",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kampen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8265",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kampen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8266",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kampen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8267",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kampen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8269",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Reeve",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8271",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJsselmuiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8274",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wilsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8275",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'s-Heerenbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8276",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zalk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8277",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grafhorst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8278",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kamperveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8281",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Genemuiden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8291",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mastenbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8293",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mastenbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8294",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mastenbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8301",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmeloord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8302",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmeloord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8303",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmeloord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8304",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmeloord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8305",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Emmeloord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8307",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8308",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nagele",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8309",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tollebeek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8311",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Espel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8312",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Creil",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8313",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rutten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8314",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bant",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8315",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Luttelgeest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8316",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Marknesse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8317",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kraggenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8319",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schokland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8321",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Urk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8322",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Urk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8323",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Urk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8325",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vollenhove",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8326",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Jansklooster",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8331",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steenwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8332",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steenwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8333",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steenwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8334",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tuk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8335",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Witte Paarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8336",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baars",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8337",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Pol",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8338",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Willemsoord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8339",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Marijenkampen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8341",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steenwijkerwold",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8342",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Basse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8343",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8344",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Onna",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8345",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kallenkote",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8346",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Bult",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8347",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eesveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8351",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wapserveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8355",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Giethoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8356",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blokzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8361",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJsselham",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8362",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nederland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8363",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wetering",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8371",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Scheerwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8372",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baarlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8373",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blankenham",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8374",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kuinre",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8375",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldemarkt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8376",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ossenzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8377",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kalenberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8378",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Paasloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8381",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vledder",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8382",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Frederiksoord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8383",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijensleek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8384",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wilhelminaoord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8385",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vledderveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8386",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doldersum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8387",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boschoord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8388",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterstreek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8389",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zandhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8391",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8392",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8393",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vinkega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8394",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Hoeve",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8395",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steggerda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8396",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Peperga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8397",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Blesse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8398",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blesdijke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8401",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gorredijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8403",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jonkerslân",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8404",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Langezwaag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8405",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Luxwoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8406",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tijnje",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8407",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terwispel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8408",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lippenhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8409",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hemrik",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8411",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jubbega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8412",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoornsterzwaag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8413",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudehorne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8414",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwehorne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8415",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bontebok",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8421",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldeberkoop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8422",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijeberkoop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8423",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Makkinga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8424",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elsloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8425",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Langedijke",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8426",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Appelscha",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8427",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ravenswoud",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8428",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Fochteloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8431",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8432",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haule",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8433",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haulerwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8434",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waskemeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8435",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Donkerbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8437",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zorgvlied",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8438",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wateren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8439",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oude Willem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8441",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerenveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8442",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerenveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8443",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerenveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8444",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerenveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8445",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerenveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8446",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerenveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8447",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerenveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8448",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heerenveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8449",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terband",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8451",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudeschoot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8452",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuweschoot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8453",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oranjewoud",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8454",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mildam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8455",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Katlijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8456",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Knipe",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8457",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gersloot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8458",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tjalleberd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8459",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Luinjeberd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8461",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rottum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8462",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotstergaast",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8463",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rotsterhaule",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8464",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sintjohannesga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8465",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudehaske",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8466",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijehaske",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8467",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vegelinsoord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8468",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haskerdijken",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8469",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwebrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8471",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wolvega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8472",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wolvega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8474",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldeholtpade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8475",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijeholtpade",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8476",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ter Idzard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8477",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldeholtwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8478",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sonnega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8479",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldetrijne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8481",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijetrijne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8482",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spanga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8483",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Scherpenzeel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8484",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Langelille",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8485",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Munnekeburen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8486",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldelamer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8487",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijelamer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8488",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijeholtwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8489",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Slijkenburg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8491",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Akkrum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8493",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terherne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8494",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8495",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aldeboarn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8497",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goëngahuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8501",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Joure",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8502",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Joure",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8503",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Joure",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8505",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Snikzwaag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8506",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haskerhorne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8507",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rohel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8508",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delfstrahuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8511",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goingarijp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8512",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Broek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8513",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ouwsterhaule",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8514",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ouwster-Nijega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8515",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldeouwer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8516",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doniaga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8517",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Scharsterbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8521",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Nicolaasga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8522",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tjerkgaast",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8523",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Idskenhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8524",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Teroele",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8525",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Langweer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8526",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boornzwaag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8527",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Legemeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8528",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dijken",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8529",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koufurderrige",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8531",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lemmer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8532",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lemmer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8534",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eesterga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8535",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Follega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8536",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterzee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8537",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Echten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8538",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bantega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8539",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Echtenerbrug",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8541",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Akmarijp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8542",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Terkaple",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8551",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woudsend",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8552",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Smallebrugge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8553",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Indijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8554",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ypecolsga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8556",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sloten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8561",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Balk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8563",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijckel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8564",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ruigahuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8565",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sondel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8566",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijemirdum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8567",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudemirdum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8571",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harich",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8572",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rijs",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8573",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mirns",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8574",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bakhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8581",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elahuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8582",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8583",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kolderwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8584",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hemelum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8601",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sneek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8602",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sneek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8603",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sneek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8604",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sneek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8605",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sneek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8606",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sneek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8607",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sneek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8608",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sneek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8611",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gaastmeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8612",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Idzega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8613",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sandfirden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8614",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8615",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blauwhuis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8616",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westhem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8617",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Abbega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8618",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosthem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8621",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heeg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8622",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hommerts",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8623",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jutrijp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8624",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uitwellingerga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8625",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oppenhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8626",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Offingawier",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8627",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gauw",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8628",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goënga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8629",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Scharnegoutum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8631",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loënga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8632",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tirns",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8633",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ysbrechtum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8635",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boazum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8636",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Britswert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8637",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wiuwert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8641",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rien",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8642",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lytsewierrum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8644",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dearsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8647",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sibrandabuorren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8651",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "IJlst",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8658",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Greonterp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8701",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bolsward",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8702",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bolsward",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8711",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Workum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8713",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hindeloopen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8715",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stavoren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8721",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warns",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8722",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Molkwerum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8723",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koudum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8724",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "It Heidenskip",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8731",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wommels",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8732",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kûbaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8733",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Iens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8734",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Easterein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8735",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Itens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8736",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Reahûs",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8737",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hidaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8741",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hartwerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8742",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Burgwerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8743",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hichtum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8744",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schettens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8745",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Longerhouw",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8746",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schraard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8747",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wons",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8748",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Witmarsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8749",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Pingjum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8751",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zurich",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8752",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kornwerderzand",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8753",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Cornwerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8754",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Makkum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8755",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Idsegahuizum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8756",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Piaam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8757",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gaast",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8758",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Allingawier",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8759",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Exmorra",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8761",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ferwoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8762",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hieslum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8763",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Parrega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8764",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dedgum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8765",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tjerkwerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8766",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Breezanddijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8771",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8772",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tjalhuizum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8773",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Folsgare",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8774",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wolsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8775",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijhuizum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8801",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Franeker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8802",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Franeker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8804",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tzum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8805",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hitzum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8806",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Achlum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8807",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Herbaijum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8808",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dongjum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8809",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8811",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ried",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8812",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Peins",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8813",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schalsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8814",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zweins",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8816",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Skingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8821",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kimswerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8822",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Arum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8823",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lollum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8831",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8832",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Húns",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8833",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leons",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8834",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8835",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Easterlittens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8841",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baaium",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8842",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wjelsryp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8843",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spannum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8844",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hinnaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8845",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waaksens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8851",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tzummarum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8852",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Firdgum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8853",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Klooster Lidlum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8854",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterbierum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8855",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sexbierum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8856",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Pietersbierum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8857",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijnaldum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8861",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harlingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8862",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harlingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8871",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Midlum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8872",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Midlum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8881",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "West-Terschelling",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8882",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8883",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8884",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baaiduinen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8885",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kinnum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8891",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Midsland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8892",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Striep",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8893",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Landerum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8894",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Formerum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8895",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lies",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8896",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8897",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterend",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8899",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlieland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8911",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8912",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8913",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8914",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8915",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8916",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8917",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8918",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8919",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8921",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8922",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8923",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8924",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8925",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8926",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8927",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8931",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8932",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8933",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8934",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8935",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8936",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8937",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8938",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8939",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "8941",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leeuwarden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9001",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grou",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9003",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9004",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warstiens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9005",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wergea",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9006",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eagum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9007",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Idaerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9008",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Reduzum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9009",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Friens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9011",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jirnsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9012",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Raerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9013",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Poppenwier",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9014",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tersoal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9021",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Easterwierrum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9022",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mantgum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9023",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jorwert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9024",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Weidum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9025",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bears",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9026",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jellum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9027",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hilaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9031",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boksum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9032",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blessum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9033",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deinum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9034",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Marsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9035",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dronryp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9036",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Menaam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9037",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Slappeterp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9038",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ingelum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9041",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Berltsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9043",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wier",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9044",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bitgum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9045",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bitgummole",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9047",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Minnertsga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9051",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stiens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9053",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Feinsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9054",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hijum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9055",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Britsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9056",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Koarnjum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9057",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jelsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9061",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gytsjerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9062",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oentsjerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9063",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mûnein",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9064",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aldtsjerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9067",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Readtsjerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9071",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alde Leie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9072",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nij Altoenae",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9073",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Marrum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9074",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hallum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9075",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westhoek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9076",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "St.-Annaparochie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9077",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vrouwenparochie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9078",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudebildtzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9079",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "St.-Jacobiparochie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9081",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lekkum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9082",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Miedum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9083",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Snakkerburen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9084",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Goutum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9085",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Teerns",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9086",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hempens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9087",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Swichum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9088",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wirdum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9089",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wytgaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9091",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wyns",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9101",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dokkum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9102",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dokkum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9103",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Dokkum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9104",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Damwâld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9105",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rinsumageast",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9106",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sibrandahûs",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9107",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jannum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9108",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Broeksterwâld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9109",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Falom",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9111",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Burdaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9112",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Burdaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9113",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wâlterswâld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9114",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Driezum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9121",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aalsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9122",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wetsens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9123",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mitselwier",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9124",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jouswier",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9125",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eastrum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9131",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9132",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ingwierrum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9133",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eanjum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9134",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ljussens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9135",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Moarre",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9136",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Peazens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9137",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Easternijtsjerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9138",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijewier",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9141",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wierum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9142",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Moddergat",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9143",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9144",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hantumhuzen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9145",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ternaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9146",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hantumerútbuorren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9147",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hantum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9148",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hiaure",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9151",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Holwert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9152",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waaxens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9153",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Brantgum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9154",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Foudgum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9155",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Raard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9156",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boarnwert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9161",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hollum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9162",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ballum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9163",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nes",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9164",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Buren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9166",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schiermonnikoog",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9171",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blije",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9172",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ferwert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9173",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hegebeintum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9174",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ginnum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9175",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Reitsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9176",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lichtaard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9177",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jislum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9178",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wânswert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9201",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drachten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9202",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drachten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9203",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drachten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9204",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drachten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9205",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drachten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9206",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drachten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9207",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drachten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9211",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kortehemmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9212",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boornbergum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9213",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Wilgen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9214",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Smalle Ee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9215",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Veenhoop",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9216",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9217",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijega",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9218",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Opeinde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9219",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Tike",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9221",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rottevalle",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9222",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drachtstercompagnie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9223",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Houtigehage",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9231",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Surhuisterveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9233",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boelenslaan",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9241",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijnjewoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9243",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bakkeveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9244",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beetsterzwaag",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9245",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nij Beets",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9246",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Olterterp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9247",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ureterp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9248",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Siegerswoude",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9249",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Frieschepalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9251",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Burgum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9254",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hurdegaryp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9255",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tytsjerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9256",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ryptsjerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9257",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noardburgum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9258",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jistrum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9261",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eastermar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9262",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sumar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9263",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Garyp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9264",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Earnewâld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9265",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Suwâld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9269",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Feanwâlden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9271",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Westereen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9281",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harkema",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9283",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Surhuizum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9284",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Augustinusga",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9285",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Buitenpost",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9286",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Twijzel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9287",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Twijzelerheide",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9288",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kootstertille",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9289",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drogeham",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9291",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kollum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9292",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Augsbuert-Lytsewâld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9293",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kollumerpomp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9294",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aldwâld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9295",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westergeast",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9296",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Trieme",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9297",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Feankleaster",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9298",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kollumersweach",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9299",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sweagerbosk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9301",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9302",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9304",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lieveren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9305",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roderesch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9306",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alteveer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9307",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steenbergen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9311",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Roden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9312",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nietap",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9313",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leutingewolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9314",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Foxwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9315",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roderwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9321",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Peize",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9331",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Norg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9333",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Langelo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9334",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Peest",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9335",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidvelde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9336",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huis ter Heide",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9337",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westervelde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9341",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veenhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9342",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Een",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9343",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Een-West",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9351",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9354",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zevenhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9355",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Midwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9356",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tolbert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9359",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boerakker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9361",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boerakker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9362",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Boerakker",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9363",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Marum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9364",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nuis",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9365",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Niebert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9366",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Jonkersvaart",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9367",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Wilp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9401",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Assen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9402",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Assen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9403",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Assen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9404",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Assen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9405",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Assen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9406",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Assen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9407",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Assen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9408",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Assen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9409",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loon",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9411",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beilen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9412",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beilen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9413",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beilen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9414",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hooghalen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9415",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hijken",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9416",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oranje",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9417",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spier",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9418",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wijster",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9419",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drijber",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9421",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bovensmilde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9422",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Smilde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9423",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogersmilde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9431",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westerbork",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9432",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9433",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zwiggelte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9434",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eursinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9435",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bruntinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9436",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mantinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9437",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Balinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9438",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Garminge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9439",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Witteveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9441",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Orvelte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9442",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Elp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9443",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schoonloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9444",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grolloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9445",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vredenheim",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9446",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Amen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9447",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Papenvoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9448",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Marwijksoord",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9449",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nooitgedacht",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9451",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9452",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nijlande",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9453",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eldersloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9454",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ekehaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9455",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Geelbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9456",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eleveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9457",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Deurze",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9458",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Balloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9459",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Balloërveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9461",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gieten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9462",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gasselte",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9463",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eext",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9464",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eexterzandvoort",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9465",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Anderen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9466",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gasteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9467",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Anloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9468",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Annen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9469",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schipborg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9471",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidlaren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9472",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidlaren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9473",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Groeve",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9474",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidlaarderveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9475",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Midlaren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9479",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordlaren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9481",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vries",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9482",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tynaarlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9483",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeegse",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9484",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudemolen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9485",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Taarlo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9486",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rhee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9487",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ter Aard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9488",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeijerveld",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9489",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeijerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9491",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeijen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9492",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ubbena",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9493",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "De Punt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9494",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Yde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9495",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9496",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bunne",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9497",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Donderen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9501",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stadskanaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9502",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stadskanaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9503",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stadskanaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9511",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gieterveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9512",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwediep",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9514",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gasselternijveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9515",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gasselternijveenschemond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9521",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw-Buinen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9523",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drouwenermond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9524",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Buinerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9525",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drouwenerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9526",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bronnegerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9527",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bronneger",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9528",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Buinen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9531",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Borger",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9533",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drouwen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9534",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9535",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ellertshaar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9536",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ees",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9537",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eesergroen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9541",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vlagtwedde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9545",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bourtange",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9551",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sellingen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9561",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ter Apel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9563",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ter Apelkanaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9564",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zandberg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9566",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veelerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9571",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "2e Exloërmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9573",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "1e Exloërmond",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9574",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Exloërveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9581",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Musselkanaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9584",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mussel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9585",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vledderveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9591",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Onstwedde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9601",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogezand",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9602",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogezand",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9603",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hoogezand",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9605",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kiel-Windeweer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9606",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kropswolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9607",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Foxhol",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9608",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westerbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9609",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Waterhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9611",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sappemeer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9613",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meerstad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9614",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harkstede GN",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9615",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kolham",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9616",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Scharmer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9617",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Harkstede",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9618",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woudbloem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9619",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Froombosch",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9621",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Slochteren",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9622",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lageland GN",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9623",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lageland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9624",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Luddeweer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9625",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Overschild",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9626",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schildwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9627",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hellum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9628",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Siddeburen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9629",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Steendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9631",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Borgercompagnie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9632",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Borgercompagnie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9633",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tripscompagnie",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9635",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9636",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidbroek",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9641",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9642",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9644",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9645",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9646",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Veendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9648",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wildervank",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9649",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Muntendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9651",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meeden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9654",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Annerveenschekanaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9655",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oud Annerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9656",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijkerboor",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9657",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw Annerveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9658",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eexterveen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9659",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eexterveenschekanaal",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9661",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Alteveer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9663",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwe Pekela",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9665",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oude Pekela",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9671",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winschoten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9672",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winschoten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9673",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winschoten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9674",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winschoten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9675",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winschoten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9677",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Heiligerlee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9678",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westerlee",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9679",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Scheemda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9681",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Midwolda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9682",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oostwold",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9684",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Finsterwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9685",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blauwestad",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9686",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Beerta",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9687",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw Beerta",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9688",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Drieborg",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9691",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudezijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9693",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bad Nieuweschans",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9695",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bellingwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9696",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudeschans",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9697",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Blijham",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9698",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wedde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9699",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vriescheloo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9711",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9712",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9713",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9714",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9715",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9716",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9717",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9718",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9721",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9722",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9723",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9724",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9725",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9726",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9727",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9728",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9731",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9732",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9733",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9734",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9735",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9736",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9737",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9738",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9741",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9742",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9743",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9744",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9745",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9746",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9747",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Groningen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9749",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Matsloot",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9751",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haren Gn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9752",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haren Gn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9753",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Haren Gn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9755",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Onnen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9756",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Glimmen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9761",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eelde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9765",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Paterswolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9766",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eelderwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9771",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sauwerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9773",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wetsinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9774",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Adorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9781",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bedum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9784",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9785",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9791",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ten Boer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9792",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ten Post",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9793",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winneweer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9794",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lellens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9795",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woltersum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9796",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sint Annen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9797",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Thesinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9798",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Garmerwolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9801",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuidhorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9804",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordhorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9805",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Briltil",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9811",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enumatil",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9812",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Enumatil",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9821",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldekerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9822",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Niekerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9824",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Noordwijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9825",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lucaswolde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9827",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lettelbert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9828",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oostwold",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9831",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Aduard",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9832",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Horn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9833",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Ham",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9841",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Niezijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9842",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Niezijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9843",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grijpskerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9844",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Pieterzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9845",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Visvliet",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9851",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Burum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9852",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warfstermolen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9853",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Munnekezijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9861",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Grootegast",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9862",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Sebaldeburen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9863",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Doezum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9864",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kornhorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9865",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Opende",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9866",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lutjegast",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9871",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stroobos",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9872",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stroobos",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9873",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Gerkesklooster",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9881",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kommerzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9882",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kommerzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9883",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldehove",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9884",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Niehove",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9885",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lauwerzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9886",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Saaksum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9891",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ezinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9892",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Feerwerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9893",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Garnwerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9901",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Appingedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9902",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Appingedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9903",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Appingedam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9904",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Krewerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9905",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Holwierde",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9906",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Bierum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9907",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Losdorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9908",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Godlinze",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9909",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Spijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9911",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosterwijtwerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9912",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leermens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9913",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eenum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9914",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zeerijp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9915",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'t Zandt",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9917",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wirdum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9918",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Garrelsweer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9919",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Loppersum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9921",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stedum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9922",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westeremden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9923",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Garsthuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9924",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Startenhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9925",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Startenhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9931",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delfzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9932",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delfzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9933",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delfzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9934",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Delfzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9936",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Farmsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9937",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Meedhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9939",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tjuchem",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9942",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "'t Waar",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9943",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuw Scheemda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9944",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Nieuwolda",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9945",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wagenborgen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9946",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Woldendorp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9947",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Termunten",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9948",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Termunterzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9949",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Borgsweer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9951",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Winsum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9953",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Baflo",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9954",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Tinallinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9955",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rasquert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9956",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Den Andel",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9957",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Saaxumhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9959",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Onderdendam",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9961",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Mensingeweer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9962",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Schouwerzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9963",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warfhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9964",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Wehe-den Hoorn",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9965",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Leens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9966",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zuurdijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9967",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eenrum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9968",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Pieterburen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9969",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westernieland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9971",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Ulrum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9972",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Niekerk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9973",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Houwerzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9974",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zoutkamp",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9975",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Vierhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9976",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Lauwersoog",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9977",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kloosterburen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9978",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Hornhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9979",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eemshaven",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9981",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uithuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9982",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Uithuizermeeden",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9983",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Roodeschool",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9984",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oudeschip",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9985",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oosternieland",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9986",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Oldenzijl",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9987",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zijldijk",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9988",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Usquert",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9989",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Warffum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9991",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Middelstum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9992",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Huizinge",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9993",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Westerwijtwerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9994",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Toornwerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9995",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Kantens",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9996",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Eppenhuizen",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9997",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Zandeweer",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9998",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Rottum",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  },
+  {
+    "code": "9999",
+    "country_id": 156,
+    "country_code": "NL",
+    "locality_name": "Stitswerd",
+    "type": "area",
+    "source": "bag-via-mevdschee"
+  }
+]


### PR DESCRIPTION
## Summary
- Imports the Netherlands' 4-digit postcode districts (PC4) for #1039
- 4,072 records, country-only state FK (matches SE/SI/GB precedent)
- Aggregated from 9M+ street-level rows in mevdschee/postcodes-nl

## Source
- [`mevdschee/postcodes-nl`](https://github.com/mevdschee/postcodes-nl) — LGPL-3 mirror, 17 MB 7zip / 401 MB CSV (v26.03 release)
- Upstream: Dutch Kadaster / BAG (Basisregistratie Adressen en Gebouwen) public open data

## Why PC4 (not PC6)
Unique PC6 codes total **467,109**. JSON-export at PC6 level would produce ~70 MB, exceeding the in-band cities/*.json envelope (PT.json at 38 MB is current largest). PC4 is the standard Dutch district-level granularity (~4,000 districts), comparable to UK postcode areas and Canada FSAs.

## Why country-only state FK
Dutch PC4 ranges span multiple provinces with overlap (e.g. PC4 1xxx covers Noord-Holland and Flevoland). 1:1 mapping would be misleading. Matches the SE / SI / GB precedent.

## Pipeline
1. Resolve latest release URL via GitHub API
2. Fetch 17 MB 7zip archive
3. Extract via `py7zr` → 401 MB CSV
4. Stream-aggregate 9M+ rows to (PC4, woonplaats) counts
5. Pick most-common woonplaats per PC4 as representative locality

## Regex fix
Old: `^\d{4}\s?[a-zA-Z]{2}$` (PC6 only)
New: `^\d{4}(?:\s?[A-Za-z]{2})?$` — accepts PC4 + PC6 with/without space

Matches the mixed-granularity pattern already permitted for GB / TW / CA / IR.

## Dependency
Adds runtime dependency on `py7zr` (LGPL, pure-Python 7zip reader). Install via `python3 -m pip install py7zr`.

## Sample rows
| code | locality |
|---|---|
| 1011 | Amsterdam |
| 1012 | Amsterdam |
| 9997 | Zandeweer |
| 9999 | Stitswerd |

## Test plan
- [x] `python3 -m py_compile bin/scripts/sync/import_netherlands_postcodes.py`
- [x] All 4,072 codes match `^\d{4}(?:\s?[A-Za-z]{2})?$`
- [x] Country-only (no `state_id`); follows SE/SI/GB pattern
- [x] No auto-managed fields (`id`, `created_at`, `updated_at`, `flag`)
- [x] Idempotent merge (re-run produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)