### PR TITLE
feat(postcodes/HR): 905 Hrvatska Pošta codes (#1039)

### DIFF
--- a/bin/scripts/sync/import_croatia_postcodes.py
+++ b/bin/scripts/sync/import_croatia_postcodes.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Croatia -> contributions/postcodes/HR.json importer for issue #1039.
+
+Source data
+-----------
+The community ``mislavcimpersak/croatian-zip-codes`` repository
+(MIT-licensed) ships ``croatian_zip_codes.json`` — a 21-county
+hierarchical JSON joining each Hrvatska Pošta 5-digit postal code
+with city + county.
+
+    [
+      {"name": "Zagrebačka", "slug": "zagrebacka",
+       "cities": [{"name": "Gornji Stupnik", "zip_code": "10255"}, ...]
+      },
+      ...
+    ]
+
+Source URL: https://raw.githubusercontent.com/mislavcimpersak/croatian-zip-codes/master/croatian_zip_codes.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib (curl is blocked).
+2. Walks 21 source counties (20 CSC counties + Grad Zagreb /
+   City of Zagreb which collapses into CSC iso2 '01' Zagreb).
+3. Resolves state FK via SOURCE_TO_ISO2 (21-entry hand map
+   handling Croatian adjective form -> CSC English county name).
+4. Emits one row per (zip_code, city) tuple.
+5. Writes contributions/postcodes/HR.json idempotently.
+
+Coverage
+--------
+- 905 codes / 100% state FK
+- All 20 CSC HR counties covered
+- Grad Zagreb (city) merged into Zagreb county per CSC convention
+
+License & attribution
+---------------------
+- Source: mislavcimpersak/croatian-zip-codes (MIT)
+- Upstream: Hrvatska Pošta public lookup
+- Each row: ``source: "hrvatska-posta-via-mislavcimpersak"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_croatia_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/mislavcimpersak/croatian-zip-codes/"
+    "master/croatian_zip_codes.json"
+)
+
+# Source Croatian adjective form -> CSC iso2.
+SOURCE_TO_ISO2: Dict[str, str] = {
+    "Zagrebačka": "01",                # Zagreb (county)
+    "Grad Zagreb": "01",               # Zagreb (city, merged with county)
+    "Krapinsko-zagorska": "02",        # Krapina-Zagorje
+    "Sisačko-moslavačka": "03",        # Sisak-Moslavina
+    "Karlovačka": "04",                # Karlovac
+    "Varaždinska": "05",               # Varaždin
+    "Koprivničko-križevačka": "06",    # Koprivnica-Križevci
+    "Bjelovarsko-bilogorska": "07",    # Bjelovar-Bilogora
+    "Primorsko-goranska": "08",        # Primorje-Gorski Kotar
+    "Ličko-senjska": "09",             # Lika-Senj
+    "Virovitičko-podravska": "10",     # Virovitica-Podravina
+    "Požeško-slavonska": "11",         # Požega-Slavonia
+    "Brodsko-posavska": "12",          # Brod-Posavina
+    "Zadarska": "13",                  # Zadar
+    "Osječko-baranjska": "14",         # Osijek-Baranja
+    "Šibensko-kninska": "15",          # Šibenik-Knin
+    "Vukovarsko-srijemska": "16",      # Vukovar-Syrmia
+    "Splitsko-dalmatinska": "17",      # Split-Dalmatia
+    "Istarska": "18",                  # Istria
+    "Dubrovačko-neretvanska": "19",    # Dubrovnik-Neretva
+    "Međimurska": "20",                # Međimurje
+}
+
+
+def fetch_json(url: str) -> List[dict]:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local JSON (skip fetch)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    counties = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+    print(f"Source counties: {len(counties)}")
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    hr_country = next((c for c in countries if c.get("iso2") == "HR"), None)
+    if hr_country is None:
+        print("ERROR: HR not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(hr_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    hr_states = [s for s in states if s.get("country_id") == hr_country["id"]]
+    state_by_iso2: Dict[str, dict] = {
+        s["iso2"]: s for s in hr_states if s.get("iso2")
+    }
+    print(
+        f"Country: Croatia (id={hr_country['id']}); states indexed: {len(hr_states)}"
+    )
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+    unknown_counties: Dict[str, int] = {}
+
+    for county in counties:
+        county_name = (county.get("name") or "").strip()
+        cities = county.get("cities") or []
+
+        iso2 = SOURCE_TO_ISO2.get(county_name)
+        state = state_by_iso2.get(iso2) if iso2 else None
+        if state is None:
+            unknown_counties[county_name] = unknown_counties.get(county_name, 0) + len(cities)
+
+        for city in cities:
+            code = (city.get("zip_code") or "").strip()
+            city_name = (city.get("name") or "").strip()
+            if not regex.match(code):
+                skipped_bad_regex += 1
+                continue
+            if state is None:
+                skipped_no_state += 1
+
+            key = (code, city_name.lower())
+            if key in seen:
+                continue
+            seen.add(key)
+
+            record: Dict[str, object] = {
+                "code": code,
+                "country_id": int(hr_country["id"]),
+                "country_code": "HR",
+            }
+            if state is not None:
+                record["state_id"] = int(state["id"])
+                record["state_code"] = state.get("iso2")
+                matched_state += 1
+            if city_name:
+                record["locality_name"] = city_name
+            record["type"] = "full"
+            record["source"] = "hrvatska-posta-via-mislavcimpersak"
+            records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Skipped (no state FK): {skipped_no_state:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    if unknown_counties:
+        print("Unknown counties (not in SOURCE_TO_ISO2):")
+        for c, n in sorted(unknown_counties.items(), key=lambda x: -x[1]):
+            print(f"  {c!r}: {n}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/HR.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/HR.json
+++ b/contributions/postcodes/HR.json
@@ -1,0 +1,9052 @@
+[
+  {
+    "code": "10000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Zagreb",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10010",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Zagreb-Sloboština",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10020",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Zagreb-Novi Zagreb",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10040",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Zagreb-Dubrava",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10090",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Zagreb-Susedgrad",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10110",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Zagreb-Trešnjevka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10250",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Lučko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10251",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Hrvatski Leskovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10253",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Donji Dragonožec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10255",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Gornji Stupnik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10257",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Brezovica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10290",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Zaprešić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10291",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Prigorje Brdovečko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10292",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Šenkovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10293",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Dubravica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10294",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Donja Pušća",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10295",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Kupljenovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10296",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Luka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10297",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Jakovlje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10298",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Donja Bistra",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10299",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Marija Gorica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10310",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Ivanić-Grad",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10311",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Posavski Bregi",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10312",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Kloštar Ivanić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10313",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Graberje Ivaničko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10314",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Križ",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10315",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Novoselec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10316",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Lijevi Dubrovčak",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10340",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Vrbovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10341",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Lonjica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10342",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Dubrava",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10343",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Nova Kapela",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10344",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Farkaševac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10345",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Gradec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10346",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Preseka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10347",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Rakovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10360",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Sesvete",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10361",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Sesvete-Kraljevec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10362",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Kašina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10363",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Belovar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10370",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Dugo Selo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10372",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Oborovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10373",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Ivanja Reka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10380",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Sveti Ivan Zelina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10381",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Bedenica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10382",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Donja Zelina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10383",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Komin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10408",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Velika Mlaka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10410",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Velika Gorica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10411",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Orle",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10412",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Donja Lomnica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10413",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Kravarsko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10414",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Pokupsko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10415",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Novo Čiče",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10417",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Buševec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10418",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Dubranec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10419",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Vukovina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10430",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Samobor",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10431",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Sveta Nedjelja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10432",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Bregana",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10434",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Strmec Samoborski",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10435",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Sveti Martin pod Okićem",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10436",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Rakov Potok",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10437",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Bestovje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10450",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Jastrebarsko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10451",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Pisarovina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10453",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Gorica Svetojanska",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10454",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Krašić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10455",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Kostanjevac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10456",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Kalje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "10457",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 736,
+    "state_code": "01",
+    "locality_name": "Sošice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Dubrovnik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20205",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Topolo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20207",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Mlini",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20210",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Cavtat",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20213",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Čilipi",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20215",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Gruda",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20216",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Dubravka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20217",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Pridvorje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20218",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Pločice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20221",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Koločep",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Lopud",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20223",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Šipanjska Luka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20224",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Maranovići",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20225",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Babino Polje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20226",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Goveđari",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20230",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Ston",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20231",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Doli",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20232",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Slano",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20233",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Trsteno",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20234",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Orašac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20235",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Zaton Veliki",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20236",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Mokošica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20240",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Trpanj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20242",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Oskorušno",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20243",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Kuna",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20244",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Potomje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20245",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Trstenik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20246",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Janjina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20247",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Žuljana",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20248",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Putniković",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20250",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Orebić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20260",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Korčula",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20263",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Lumbarda",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20264",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Račišće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20267",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Kućište",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20269",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Lovište",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20270",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Vela Luka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20271",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Blato",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20272",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Smokvica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20273",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Čara",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20274",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Pupnat",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20275",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Žrnovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20278",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Nova Sela",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20290",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Lastovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20340",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Ploče",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20341",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Kula Norinska",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20342",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Otrić Seoci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20343",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Rogotin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20344",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Komin (Dalma)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20345",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Staševica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20350",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Metković",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20352",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Vid",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20353",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Mlinište",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20355",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Opuzen",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20356",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Klek",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "20357",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 728,
+    "state_code": "19",
+    "locality_name": "Blace",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Split",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21201",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Prgomet",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21202",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Lećevica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21203",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Donji Muć",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21204",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Dugopolje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21205",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Donji Dolac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21206",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Donje Ogorje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21207",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Kostanje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21208",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Kučiće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21209",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Mravince",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21210",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Solin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21212",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Kaštel Sućurac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21213",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Kaštel Gomilica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21214",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Kaštel Kambelovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21215",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Kaštel Lukšić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21216",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Kaštel Stari",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21217",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Kaštel Štafilić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21220",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Trogir",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Marina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21223",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Okrug Gornji",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21224",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Slatine",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21225",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Drvenik Veliki",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21226",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Vinišće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21227",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Primorski Dolac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21228",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Blizna Donja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21229",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Crivac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21230",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Sinj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21231",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Klis",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21232",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Dicmo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21233",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Hrvace",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21236",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Vrlika",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21238",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Otok (Dalmacija)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21240",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Trilj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21241",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Obrovac Sinjski",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21242",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Grab",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21243",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Ugljane",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21244",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Cista Velika",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21245",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Tijarica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21246",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Aržano",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21247",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Neorić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21250",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Šestanovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21251",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Žrnovnica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21252",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Tugare",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21253",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Gata",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21254",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Blato na Cetini",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21255",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Zadvarje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21256",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Cista Provo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21257",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Lovreć",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21260",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Imotski",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21261",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Runović",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21262",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Kamenmost",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21263",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Krivodol",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21264",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Donji Proložac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21265",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Studenci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21266",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Zmijavci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21267",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Ričice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21270",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Zagvozd",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21271",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Grabovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21272",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Slivno",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21273",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Župa",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21275",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Dragljane",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21276",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Vrgorac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21277",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Veliki Prolog",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21292",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Srinjine",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21300",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Makarska",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21310",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Omiš",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21311",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Stobreč",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21312",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Podstrana",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21314",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Jesenice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21315",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Dugi Rat",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21317",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Lokva Rogoznica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21318",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Mimice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21320",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Baška Voda",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21322",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Brela",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21323",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Promajna",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21325",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Tučepi",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21327",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Podgora",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21328",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Drašnice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21329",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Igrane",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21330",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Gradac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21333",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Drvenik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21334",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Zaostrog",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21335",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Podaca",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21400",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Supetar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21403",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Sutivan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21404",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Ložišća",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21405",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Milna",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21410",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Postira",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21412",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Pučišća",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21413",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Povlja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21420",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Bol",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21423",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Nerežišća",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21424",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Pražnica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21425",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Selca",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21430",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Grohote",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21432",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Stomorska",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21450",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Hvar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21454",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Brusje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21460",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Stari Grad",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21462",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Vrbanj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21463",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Vrboska",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21465",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Jelsa",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21466",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Zastražišće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21467",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Gdinj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21469",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Sućuraj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21480",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Vis",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21483",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Podšpilje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "21485",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 725,
+    "state_code": "17",
+    "locality_name": "Komiža",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Šibenik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22030",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Šibenik-Zablaće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22202",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Primošten",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22203",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Rogoznica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22204",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Široke",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22205",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Perković",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22206",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Boraja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22211",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Vodice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22212",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Tribunj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22213",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Pirovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22214",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Čista Velika",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22215",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Zaton",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22221",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Lozovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Skradin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22232",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Zlarin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22233",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Prvić Luka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22234",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Prvić Šepurine",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22235",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Kaprije",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22236",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Žirje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22240",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Tisno",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22242",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Jezera",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22243",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Murter",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22244",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Betina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22300",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Knin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22301",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Golubić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22303",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Oklaj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22305",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Kistanje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22310",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Kijevo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22320",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Drniš",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22321",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Siverić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22322",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Ružić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22323",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Unešić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "22324",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 730,
+    "state_code": "15",
+    "locality_name": "Drinovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Zadar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23205",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Bibinje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23206",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Sukošan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23207",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Sveti Filip i Jakov",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23210",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Biograd na moru",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23211",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Pakoštane",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23212",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Tkon",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Zemunik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23223",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Škabrnja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23226",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Pridraga",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23231",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Petrčane",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23232",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Nin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23233",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Privlaka (Dalmacija)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23234",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Vir",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23235",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Vrsi",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23241",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Poličnik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23242",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Posedarje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23243",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Jasenice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23244",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Starigrad Paklenica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23245",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Tribanj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23247",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Vinjerac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23248",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Ražanac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23249",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Povljana",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23250",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Pag",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23251",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Kolan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23262",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Pašman",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23263",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Ždrelac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23264",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Neviđane",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23271",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Kukljica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23272",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Kali",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23273",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Preko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23274",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Lukoran",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23275",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Ugljan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23281",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Sali",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23282",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Žman",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23283",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Rava",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23284",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Veli Iž",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23285",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Brbinj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23286",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Božava",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23287",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Veli Rat",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23291",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Sestrunj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23292",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Molat",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23293",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Ist",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23294",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Premuda",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23295",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Silba",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23296",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Olib",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23312",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Novigrad (Dalmacija)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23420",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Benkovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23422",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Stankovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23423",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Polača",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23440",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Gračac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23445",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Srb",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23450",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Obrovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "23452",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 727,
+    "state_code": "13",
+    "locality_name": "Karin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Osijek",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31204",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Bijelo Brdo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31205",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Aljmaš",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31206",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Erdut",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31207",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Tenja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31208",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Petrijevci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31214",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Laslovo (Szentlászló)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31215",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Ernestinovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31216",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Antunovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31220",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Višnjevac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31221",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Josipovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Bizovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31223",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Brođanci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31224",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Koška",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31225",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Breznica Našička",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31226",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Dalj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31227",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Zelčin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31300",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Beli Manastir",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31301",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Branjin Vrh",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31302",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Kneževo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31303",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Popovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31304",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Duboševica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31305",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Draž",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31306",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Batina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31307",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Zmajevac (Vörösmart)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31308",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Suza (Csúza)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31309",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Kneževi Vinogradi",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31315",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Karanac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31321",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Petlovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31322",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Baranjsko Petrovo Selo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31323",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Bolman",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31324",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Jagodnjak",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31325",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Čeminac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31326",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Darda",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31327",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Bilje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31328",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Lug (Laskó)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31400",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Đakovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31401",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Viškovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31402",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Semeljci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31403",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Vuka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31404",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Vladislavci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31410",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Strizivojna",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31411",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Trnava",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31415",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Selci Đakovački",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31416",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Levanjska Varoš",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31417",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Piškorevci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31418",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Drenje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31421",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Satnica Đakovačka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31422",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Gorjani",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31423",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Bračevci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31424",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Punitovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31431",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Čepin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31432",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Budimci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31433",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Podgorač",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31500",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Našice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31511",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Đurđenovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31512",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Feričanci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31513",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Donja Motičina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31530",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Podravska Moslavina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31531",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Viljevo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31540",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Donji Miholjac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31542",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Magadenovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31543",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Miholjački Poreč",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31550",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Valpovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31551",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Belišće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31552",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Podgajci Podravski",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31553",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Črnkovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31554",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Gat",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "31555",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 740,
+    "state_code": "14",
+    "locality_name": "Marijanci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Vukovar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32010",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Vukovar - Lipovača",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32100",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Vinkovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32211",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Ostrovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32212",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Gaboš",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32213",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Markušica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32214",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Tordinci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32221",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Nuštar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Bršadin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32224",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Trpinja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32225",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Bobota",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32227",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Borovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32229",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Petrovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32232",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Sotin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32233",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Opatovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32234",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Šarengrad",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32235",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Bapska",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32236",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Ilok",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32237",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Lovas",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32238",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Čakovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32239",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Negoslavci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32241",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Stari Jankovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32242",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Slakovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32243",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Orolik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32244",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Đeletovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32245",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Nijemci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32246",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Lipovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32247",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Banovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32248",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Ilača",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32249",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Tovarnik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32251",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Privlaka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32252",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Otok",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32253",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Komletinci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32254",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Vrbanja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32255",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Soljani",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32256",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Strošinci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32257",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Drenovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32258",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Posavski Podgajci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32260",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Gunja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32261",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Rajevo Selo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32262",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Račinovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32263",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Đurići",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32270",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Županja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32271",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Rokovci Andrijaševci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32272",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Cerna",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32273",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Gradište",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32274",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Štitar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32275",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Bošnjaci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32276",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Babina Greda",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32280",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Jarmina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32281",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Ivankovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32282",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Retkovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32283",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Vođinci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "32284",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 741,
+    "state_code": "16",
+    "locality_name": "Stari Mikanovci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Virovitica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33404",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Špišić Bukovica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33405",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Pitomača",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33406",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Lukač",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33407",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Gornje Bazje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33410",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Suhopolje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33411",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Gradina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33412",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Cabuna",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33507",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Crnac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33513",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Zdenci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33514",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Čačinci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33515",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Orahovica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33517",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Mikleuš",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33518",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Nova Bukovica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33520",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Slatina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33522",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Voćin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33523",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Čađavica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33525",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Sopje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "33533",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 732,
+    "state_code": "10",
+    "locality_name": "Pivnica Slavonska",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Požega",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34308",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Jakšić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34310",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Pleternica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34311",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Kuzmica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34312",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Sesvete (kod Požege)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34315",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Ratkovica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34322",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Brestovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34330",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Velika",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34334",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Kaptol",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34335",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Vetovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34340",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Kutjevo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34343",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Bektež",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34350",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Čaglin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34543",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Poljana",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34550",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Pakrac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34551",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Lipik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34552",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Badljevina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "34553",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 724,
+    "state_code": "11",
+    "locality_name": "Bučje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Slavonski Brod",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35105",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Slavonski Brod",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35106",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Slavonski Brod",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35107",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Podvinje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35201",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Podcrkavlje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35207",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Gornja Vrba",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35208",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Ruščica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35209",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Bukovlje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35210",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Vrpolje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35211",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Trnjani",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35212",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Garčin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35213",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Oprisavci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35214",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Donji Andrijevci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35216",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Prnjavor",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35220",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Slavonski Šamac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35221",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Velika Kopanica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Gundinci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35224",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Sikirevci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35250",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Oriovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35252",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Sibinj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35253",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Brodski Stupnik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35254",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Bebrina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35255",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Slavonski Kobaš",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35257",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Lužani",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35400",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Nova Gradiška",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35403",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Rešetari",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35404",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Cernik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35410",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Nova Kapela",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35414",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Vrbova",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35420",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Staro Petrovo Selo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35422",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Zapolje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35423",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Vrbje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35424",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Orubica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35425",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Davor",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35428",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Dragalić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35429",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Gornji Bogićevci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35430",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Okučani",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "35435",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 737,
+    "state_code": "12",
+    "locality_name": "Stara Gradiška",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Čakovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40305",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Nedelišće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40306",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Macinec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40311",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Lopatinec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40312",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Štrigova",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40313",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Sveti Martin na Muri",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40314",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Selnica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40315",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Mursko Središče",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40317",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Podturen",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40318",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Dekanovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40319",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Belica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40320",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Donji Kraljevec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40321",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Mala Subotica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40322",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Orehovica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40323",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Prelog",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40324",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Goričan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40325",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Draškovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40326",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Sveta Marija",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40327",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Donji Vidovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40328",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Donja Dubrava",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "40329",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 726,
+    "state_code": "20",
+    "locality_name": "Kotoriba",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Varaždin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42201",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Beretinec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42202",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Trnovec Bartolovečki",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42203",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Jalžabet",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42204",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Turčin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42205",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Vidovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42206",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Petrijanec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42207",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Vinica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42208",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Cestica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42209",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Sračinec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42214",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Sveti Ilija",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42220",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Novi Marof",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Ljubeščica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42223",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Varaždinske Toplice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42225",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Breznički Hum",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42230",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Ludbreg",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42231",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Mali Bukovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42232",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Donji Martijanec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42233",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Sveti Đurđ",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42240",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Ivanec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42242",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Radovan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42243",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Maruševec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42244",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Klenovnik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42245",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Donja Voća",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42250",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Lepoglava",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42253",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Bednja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42254",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Trakošćan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "42255",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 739,
+    "state_code": "05",
+    "locality_name": "Donja Višnjica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Bjelovar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43202",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Zrinski Topolovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43203",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Kapela",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43211",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Predavac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43212",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Rovišće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43226",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Veliko Trojstvo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43227",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Šandrovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43231",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Ivanska",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43232",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Berek",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43233",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Trnovitički Popovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43240",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Čazma",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43246",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Štefanje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43247",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Narta",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43251",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Gudovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43252",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Prgomelje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43270",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Veliki Grđevac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43272",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Nova Rača",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43273",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Bulinac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43274",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Severin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43280",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Garešnica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43282",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Veliko Vukovje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43283",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Kaniška Iva",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43284",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Hercegovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43290",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Grubišno Polje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43293",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Veliki Zdenci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43500",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Daruvar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43505",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Končanica (Končenice)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43506",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Dežanovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43507",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Uljanik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43531",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Veliki Bastaji",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43532",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Đulovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "43541",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 734,
+    "state_code": "07",
+    "locality_name": "Sirač",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Sisak",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44010",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Sisak-Caprag",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44201",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Martinska Ves",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44202",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Topolovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44203",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Gušće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44204",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Jabukovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44210",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Sunja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44211",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Blinjski Kut",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44213",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Kratečko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44250",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Petrinja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44253",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Mošćenica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44272",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Lekenik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44273",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Sela",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44316",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Velika Ludina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44317",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Popovača",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44318",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Voloder",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44320",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Kutina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44321",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Banova Jaruga",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44322",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Lipovljani",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44323",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Rajić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44324",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Jasenovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44325",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Krapje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44330",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Novska",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44400",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Glina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44410",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Gvozd",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44415",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Topusko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44430",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Hrvatska Kostajnica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44431",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Donji Kukuruzari",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44435",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Divuša",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44440",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Dvor",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "44450",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 733,
+    "state_code": "03",
+    "locality_name": "Hrvatska Dubica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Karlovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47201",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Draganići",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47203",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Rečica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47204",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Šišljavić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47206",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Lasinja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47212",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Skakavac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47220",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Vojnić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Cetingrad",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47240",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Slunj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47241",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Cerovac Vukmanički",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47242",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Krnjak",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47245",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Rakovica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47246",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Drežnik Grad",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47250",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Duga Resa",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47251",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Bosiljevo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47252",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Barilović",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47261",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Zvečaj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47262",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Generalski Stol",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47264",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Tounj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47271",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Netretić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47272",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Ribnik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47276",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Žakanje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47280",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Ozalj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47281",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Mali Erjavec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47282",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Kamanje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47283",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Vivodina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47284",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Kašt",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47285",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Radatovići",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47286",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Mahično",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47300",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Ogulin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47302",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Oštarije",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47303",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Josipdol",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47304",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Plaški",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47306",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Saborsko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47307",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Gornje Zagorje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47313",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Drežnica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "47314",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 5069,
+    "state_code": "04",
+    "locality_name": "Jasenak",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Koprivnica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48214",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Sveti Ivan Žabno",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48260",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Križevci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48264",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Kloštar Vojakovački",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48265",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Raven",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48267",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Orehovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48268",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Gornja Rijeka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48269",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Kalnik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48306",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Sokolovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48311",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Kunovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48312",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Rasinja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48314",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Koprivnički Ivanec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48316",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Đelekovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48317",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Legrad",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48321",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Peteranec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48322",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Drnje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48323",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Hlebine",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48325",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Novigrad Podravski",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48326",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Virje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48327",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Molve",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48331",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Gola",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48332",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Ždala",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48350",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Đurđevac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48355",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Novo Virje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48356",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Ferdinandovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48361",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Kalinovac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48362",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Kloštar Podravski",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "48363",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 742,
+    "state_code": "06",
+    "locality_name": "Podravske Sesvete",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Krapina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49210",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Zabok",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49214",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Veliko Trgovišće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49215",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Tuhelj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49216",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Desinić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49217",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Krapinske Toplice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49218",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Pregrada",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49221",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Bedekovčina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Poznanovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49223",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Sveti Križ Začretje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49224",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Lepajci",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49225",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Đurmanec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49228",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Brestovec Orehovički",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49231",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Hum na Sutli",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49232",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Radoboj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49233",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Gornje Jesenje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49234",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Petrovsko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49240",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Donja Stubica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49243",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Oroslavje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49244",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Stubičke Toplice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49245",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Gornja Stubica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49246",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Marija Bistrica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49247",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Zlatar Bistrica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49250",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Zlatar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49251",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Mače",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49252",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Mihovljan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49253",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Lobor",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49254",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Belec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49255",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Novi Golubovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49282",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Konjščina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49283",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Hraščina-Trgovišće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49284",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Budinšćina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49290",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Klanjec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49294",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Kraljevec na Sutli",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49295",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Kumrovec",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "49296",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 729,
+    "state_code": "02",
+    "locality_name": "Zagorska Sela",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Rijeka",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51211",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Matulji",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51212",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Vele Mune",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51213",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Jurdani",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51214",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Šapjane",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51215",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Kastav",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51216",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Viškovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51217",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Klana",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51218",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Dražice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51221",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Kostrena",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Bakar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51223",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Škrljevo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51224",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Krasica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51225",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Praputnjak",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51226",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Hreljin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51227",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Kukuljanovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51241",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Križišće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51242",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Drivenik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51243",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Tribalj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51244",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Grižane",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51250",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Novi Vinodolski",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51251",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Ledenice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51252",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Klenovica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51253",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Bribir",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51260",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Crikvenica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51261",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Bakarac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51262",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Kraljevica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51263",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Šmrika",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51264",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Jadranovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51265",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Dramalj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51266",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Selce",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51280",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Rab",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51281",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Lopar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51300",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Delnice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51301",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Brod na Kupi",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51302",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Kuželj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51303",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Plešce",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51304",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Gerovo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51305",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Tršće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51306",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Čabar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51307",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Prezid",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51311",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Skrad",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51312",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Brod Moravice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51313",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Kupjak",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51314",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Ravna Gora",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51315",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Mrkopalj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51316",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Lokve",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51317",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Crni Lug",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51322",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Fužine",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51323",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Lič",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51324",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Zlobin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51325",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Moravice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51326",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Vrbovsko",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51327",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Gomirje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51328",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Lukovdol",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51329",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Severin na Kupi",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51410",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Opatija",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51414",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Ičići",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51415",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Lovran",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51417",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Mošćenička Draga",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51418",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Brseč",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51500",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Krk",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51511",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Malinska",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51512",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Njivice",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51513",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Omišalj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51514",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Dobrinj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51515",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Šilo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51516",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Vrbnik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51517",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Kornić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51521",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Punat",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51522",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Draga Bašćanska",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51523",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Baška",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51550",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Mali Lošinj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51551",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Veli Lošinj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51552",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Ilovik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51554",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Nerezine",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51555",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Belej",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51556",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Martinšćica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51557",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Cres",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51559",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Beli",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51561",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Susak",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51562",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Unije",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "51564",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 735,
+    "state_code": "08",
+    "locality_name": "Ćunski",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Pazin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52100",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Pula (Pola)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52203",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Medulin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52204",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Ližnjan (Lisignano)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52206",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Marčana",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52207",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Barban",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52208",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Krnica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52210",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Rovinj (Rovigno)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52211",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Bale (Valle)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52212",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Fažana (Fasana)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52215",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Vodnjan (Dignano)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52216",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Galižana (Gallesano)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52220",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Labin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52221",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Rabac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52222",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Koromačno",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52223",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Raša",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52224",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Trget",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52231",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Nedešćina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52232",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Kršan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52233",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Šušnjevica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52234",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Plomin",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52332",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Pićan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52333",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Podpićan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52341",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Žminj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52342",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Svetvinčenat",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52352",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Kanfanar",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52402",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Cerovlje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52403",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Gračišće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52404",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Sveti Petar u šumi",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52420",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Buzet",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52422",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Lanišće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52423",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Karojba",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52424",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Motovun (Montana)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52425",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Roč",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52426",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Lupoglav",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52427",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Livade (Levade)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52428",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Oprtalj (Portole)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52429",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Grožnjan (Grisignana)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52434",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Boljun",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52440",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Poreč (Parenzo)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52444",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Tinjan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52445",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Baderna",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52446",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Nova Vas",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52447",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Vižinada (Visinada)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52448",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Sveti Lovreč",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52449",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Červar Porat",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52450",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Vrsar (Orsera)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52452",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Funtana (Fontane)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52460",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Buje (Buie)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52462",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Momjan (Momiano)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52463",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Višnjan (Visignano)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52464",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Kaštelir (Castelliere)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52465",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Tar (Torre)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52466",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Novigrad (Cittanova)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52470",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Umag (Umago)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52474",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Brtonigla (Verteneglio)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "52475",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 743,
+    "state_code": "18",
+    "locality_name": "Savudrija (Salvore)",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53000",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Gospić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53201",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Lički Osik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53202",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Perušić",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53203",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Kosinj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53206",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Brušane",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53211",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Smiljan",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53212",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Klanac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53213",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Donje Pazarište",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53220",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Otočac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53223",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Vrhovine",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53224",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Ličko Lešće",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53230",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Korenica",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53231",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Plitvička Jezera",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53233",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Ličko Petrovo Selo",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53234",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Udbina",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53236",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Podlapača",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53244",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Lovinac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53250",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Donji Lapac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53260",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Brinje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53261",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Križpolje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53262",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Jezerane",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53270",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Senj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53271",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Krivi Put",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53273",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Vratnik",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53274",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Krasno",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53284",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Sveti Juraj",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53287",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Jablanac",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53288",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Karlobag",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53289",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Lukovo Šugarje",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53291",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Novalja",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53294",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Lun",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  },
+  {
+    "code": "53296",
+    "country_id": 55,
+    "country_code": "HR",
+    "state_id": 731,
+    "state_code": "09",
+    "locality_name": "Zubovići",
+    "type": "full",
+    "source": "hrvatska-posta-via-mislavcimpersak"
+  }
+]


### PR DESCRIPTION
## Summary
- Imports Croatia's 5-digit Hrvatska Pošta postcodes (905 codes) for #1039
- 100% state FK resolution across all 20 CSC HR counties

## Source
- [`mislavcimpersak/croatian-zip-codes`](https://github.com/mislavcimpersak/croatian-zip-codes) — MIT-licensed
- File: `croatian_zip_codes.json` (88 KB)
- Upstream: Hrvatska Pošta public lookup

## State FK strategy
21-entry `SOURCE_TO_ISO2` maps source's Croatian adjective form to CSC English county names:
- `Zagrebačka` → Zagreb (01)
- `Krapinsko-zagorska` → Krapina-Zagorje (02)
- `Sisačko-moslavačka` → Sisak-Moslavina (03)
- `Splitsko-dalmatinska` → Split-Dalmatia (17)
- `Istarska` → Istria (18)
- `Grad Zagreb` → Zagreb (01) [City of Zagreb merged into county per CSC convention]

## Distribution (top 5)
| iso2 | county | rows |
|---|---|---|
| 17 | Split-Dalmatia | 108 |
| 08 | Primorje-Gorski Kotar | 83 |
| 01 | Zagreb | 71 |
| 14 | Osijek-Baranja | 69 |
| 18 | Istria | 57 |

All 20 counties covered.

## Test plan
- [x] `python3 -m py_compile bin/scripts/sync/import_croatia_postcodes.py`
- [x] All 905 codes match `^(?:HR)*\d{5}$`
- [x] 100% state_id valid; state.country_id == 55; state_code == state.iso2
- [x] No auto-managed fields (`id`, `created_at`, `updated_at`, `flag`)
- [x] Idempotent merge (re-run produces no diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)