### PR TITLE
feat(postcodes): 7 singleton-territory postcodes — FK,GS,IO,PN,SH,TC,NR (#1039)

### DIFF
--- a/bin/scripts/sync/import_singleton_territory_postcodes.py
+++ b/bin/scripts/sync/import_singleton_territory_postcodes.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Singleton-postcode UK overseas territories importer for issue #1039.
+
+Source data
+-----------
+The following territories use a single fixed Royal Mail-style
+postcode each, assigned by the British postal system:
+
+    Country                    iso2  postcode     ship to
+    Falkland Islands           FK    FIQQ 1ZZ
+    South Georgia (S. Sand.)   GS    SIQQ 1ZZ
+    BIOT (Diego Garcia, ...)   IO    BBND 1ZZ
+    Pitcairn Islands           PN    PCRN 1ZZ
+    Saint Helena (Island)      SH    STHL 1ZZ
+    Ascension Island           SH    ASCN 1ZZ  (same SH country)
+    Tristan da Cunha           SH    TDCU 1ZZ  (same SH country)
+    Turks and Caicos Islands   TC    TKCA 1ZZ
+    Nauru                      NR    NRU68
+
+Source: Royal Mail / Wikipedia public references for each Crown
+Dependency or Overseas Territory's postcode assignment.
+
+What this script does
+---------------------
+Emits 7 contributions/postcodes/<iso2>.json files (SH gets all
+three Atlantic Saint-Helena-overseas postcodes in one file).
+
+State FK
+--------
+Country-only ship for all (these countries have either a single
+state or no formal sub-state postcode mapping).
+
+License & attribution
+---------------------
+Postcode assignments are public Royal Mail / national-post conventions;
+no formal license required. Each row carries
+``source: "wikipedia-singleton-territory"`` for export-time provenance.
+
+Usage
+-----
+    python3 bin/scripts/sync/import_singleton_territory_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+
+# iso2 -> list of (postcode, locality_name) tuples
+TERRITORIES: Dict[str, List[tuple]] = {
+    "FK": [("FIQQ 1ZZ", "Falkland Islands")],
+    "GS": [("SIQQ 1ZZ", "South Georgia and the South Sandwich Islands")],
+    "IO": [("BBND 1ZZ", "British Indian Ocean Territory")],
+    "PN": [("PCRN 1ZZ", "Pitcairn Islands")],
+    "SH": [
+        ("STHL 1ZZ", "Saint Helena"),
+        ("ASCN 1ZZ", "Ascension Island"),
+        ("TDCU 1ZZ", "Tristan da Cunha"),
+    ],
+    "TC": [("TKCA 1ZZ", "Turks and Caicos Islands")],
+    "NR": [("NRU68", "Nauru")],
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    countries_by_iso2 = {c["iso2"]: c for c in countries}
+
+    written: List[str] = []
+    for iso2, entries in TERRITORIES.items():
+        country = countries_by_iso2.get(iso2)
+        if country is None:
+            print(f"WARN: {iso2} not in countries.json", file=sys.stderr)
+            continue
+        regex = re.compile(country.get("postal_code_regex") or ".*")
+
+        records: List[dict] = []
+        for code, locality in entries:
+            if not regex.match(code):
+                print(
+                    f"  WARN: {iso2}/{code!r} fails regex {regex.pattern!r}",
+                    file=sys.stderr,
+                )
+                continue
+            record: Dict[str, object] = {
+                "code": code,
+                "country_id": int(country["id"]),
+                "country_code": iso2,
+                "locality_name": locality,
+                "type": "full",
+                "source": "wikipedia-singleton-territory",
+            }
+            records.append(record)
+
+        if args.dry_run:
+            print(f"  {iso2}: would write {len(records)} record(s)")
+            continue
+
+        target = project_root / f"contributions/postcodes/{iso2}.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            with target.open(encoding="utf-8") as f:
+                existing = json.load(f)
+            existing_seen = {
+                (r["code"], (r.get("locality_name") or "").lower())
+                for r in existing
+            }
+            merged = list(existing)
+            for r in records:
+                key = (r["code"], (r.get("locality_name") or "").lower())
+                if key not in existing_seen:
+                    merged.append(r)
+                    existing_seen.add(key)
+            merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+        else:
+            merged = sorted(
+                records, key=lambda r: (r["code"], r.get("locality_name", ""))
+            )
+
+        with target.open("w", encoding="utf-8") as f:
+            json.dump(merged, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        size_kb = target.stat().st_size / 1024
+        print(
+            f"  [OK] {target.relative_to(project_root)} "
+            f"({len(merged)} record(s), {size_kb:.1f} KB)"
+        )
+        written.append(iso2)
+
+    print(f"\nShipped: {len(written)} territories: {', '.join(written)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/countries/countries.json
+++ b/contributions/countries/countries.json
@@ -2272,7 +2272,7 @@
     "nationality": "BIOT",
     "area_sq_km": 60.0,
     "postal_code_format": "BBND 1ZZ",
-    "postal_code_regex": "BBND 1ZZ",
+    "postal_code_regex": "^(BBND\\s?1ZZ)$",
     "timezones": [
       {
         "zoneName": "Indian/Chagos",
@@ -4928,7 +4928,7 @@
     "nationality": "Falkland Island",
     "area_sq_km": 12173.0,
     "postal_code_format": "FIQQ 1ZZ",
-    "postal_code_regex": "FIQQ 1ZZ",
+    "postal_code_regex": "^(FIQQ\\s?1ZZ)$",
     "timezones": [
       {
         "zoneName": "Atlantic/Stanley",
@@ -10253,7 +10253,7 @@
     "nationality": "Nauruan",
     "area_sq_km": 21.0,
     "postal_code_format": "NRU68",
-    "postal_code_regex": "NRU68",
+    "postal_code_regex": "^(NRU68)$",
     "timezones": [
       {
         "zoneName": "Pacific/Nauru",
@@ -11641,7 +11641,7 @@
     "nationality": "Pitcairn Island",
     "area_sq_km": 47.0,
     "postal_code_format": "PCRN 1ZZ",
-    "postal_code_regex": "PCRN 1ZZ",
+    "postal_code_regex": "^(PCRN\\s?1ZZ)$",
     "timezones": [
       {
         "zoneName": "Pacific/Pitcairn",
@@ -12386,8 +12386,8 @@
     "subregion_id": 3,
     "nationality": "Saint Helenian",
     "area_sq_km": 410.0,
-    "postal_code_format": "STHL 1ZZ",
-    "postal_code_regex": "^(STHL1ZZ)$",
+    "postal_code_format": "STHL 1ZZ|ASCN 1ZZ|TDCU 1ZZ",
+    "postal_code_regex": "^((?:STHL|ASCN|TDCU)\\s?1ZZ)$",
     "timezones": [
       {
         "zoneName": "Atlantic/St_Helena",
@@ -13689,7 +13689,7 @@
     "nationality": "South Georgia or South Sandwich Islands",
     "area_sq_km": 3903.0,
     "postal_code_format": "SIQQ 1ZZ",
-    "postal_code_regex": "SIQQ 1ZZ",
+    "postal_code_regex": "^(SIQQ\\s?1ZZ)$",
     "timezones": [
       {
         "zoneName": "Atlantic/South_Georgia",
@@ -15067,7 +15067,7 @@
     "nationality": "Turks and Caicos Island",
     "area_sq_km": 430.0,
     "postal_code_format": "TKCA 1ZZ",
-    "postal_code_regex": "^(TKCA 1ZZ)$",
+    "postal_code_regex": "^(TKCA\\s?1ZZ)$",
     "timezones": [
       {
         "zoneName": "America/Grand_Turk",

--- a/contributions/postcodes/FK.json
+++ b/contributions/postcodes/FK.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "FIQQ 1ZZ",
+    "country_id": 71,
+    "country_code": "FK",
+    "locality_name": "Falkland Islands",
+    "type": "full",
+    "source": "wikipedia-singleton-territory"
+  }
+]

--- a/contributions/postcodes/GS.json
+++ b/contributions/postcodes/GS.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "SIQQ 1ZZ",
+    "country_id": 205,
+    "country_code": "GS",
+    "locality_name": "South Georgia and the South Sandwich Islands",
+    "type": "full",
+    "source": "wikipedia-singleton-territory"
+  }
+]

--- a/contributions/postcodes/IO.json
+++ b/contributions/postcodes/IO.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "BBND 1ZZ",
+    "country_id": 32,
+    "country_code": "IO",
+    "locality_name": "British Indian Ocean Territory",
+    "type": "full",
+    "source": "wikipedia-singleton-territory"
+  }
+]

--- a/contributions/postcodes/NR.json
+++ b/contributions/postcodes/NR.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "NRU68",
+    "country_id": 153,
+    "country_code": "NR",
+    "locality_name": "Nauru",
+    "type": "full",
+    "source": "wikipedia-singleton-territory"
+  }
+]

--- a/contributions/postcodes/PN.json
+++ b/contributions/postcodes/PN.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "PCRN 1ZZ",
+    "country_id": 175,
+    "country_code": "PN",
+    "locality_name": "Pitcairn Islands",
+    "type": "full",
+    "source": "wikipedia-singleton-territory"
+  }
+]

--- a/contributions/postcodes/SH.json
+++ b/contributions/postcodes/SH.json
@@ -1,0 +1,26 @@
+[
+  {
+    "code": "ASCN 1ZZ",
+    "country_id": 184,
+    "country_code": "SH",
+    "locality_name": "Ascension Island",
+    "type": "full",
+    "source": "wikipedia-singleton-territory"
+  },
+  {
+    "code": "STHL 1ZZ",
+    "country_id": 184,
+    "country_code": "SH",
+    "locality_name": "Saint Helena",
+    "type": "full",
+    "source": "wikipedia-singleton-territory"
+  },
+  {
+    "code": "TDCU 1ZZ",
+    "country_id": 184,
+    "country_code": "SH",
+    "locality_name": "Tristan da Cunha",
+    "type": "full",
+    "source": "wikipedia-singleton-territory"
+  }
+]

--- a/contributions/postcodes/TC.json
+++ b/contributions/postcodes/TC.json
@@ -1,0 +1,10 @@
+[
+  {
+    "code": "TKCA 1ZZ",
+    "country_id": 227,
+    "country_code": "TC",
+    "locality_name": "Turks and Caicos Islands",
+    "type": "full",
+    "source": "wikipedia-singleton-territory"
+  }
+]


### PR DESCRIPTION
## Summary
- Imports fixed single postcodes for 7 small territories (UK Crown Dependencies / Overseas Territories + Nauru) for #1039
- 9 records total (SH gets 3 for Saint Helena + Ascension + Tristan da Cunha)
- Country-only ship (matches small-territory pattern)

## Source
- Royal Mail / each national post's public postcode convention
- Each row: `source: "wikipedia-singleton-territory"`

## Coverage
| iso2 | Country | Postcode |
|---|---|---|
| FK | Falkland Islands | FIQQ 1ZZ |
| GS | South Georgia and the South Sandwich Islands | SIQQ 1ZZ |
| IO | British Indian Ocean Territory | BBND 1ZZ |
| PN | Pitcairn Islands | PCRN 1ZZ |
| SH | Saint Helena | STHL 1ZZ |
| SH | Ascension Island | ASCN 1ZZ |
| SH | Tristan da Cunha | TDCU 1ZZ |
| TC | Turks and Caicos Islands | TKCA 1ZZ |
| NR | Nauru | NRU68 |

## Regex fixes (countries.json)
Several countries had bad regex entries that this PR also corrects:
- **FK / GS / IO / PN / NR**: plain literal strings without `^...$` anchors (e.g. `"FIQQ 1ZZ"` as the raw regex would match any substring) → now `^(FIQQ\s?1ZZ)$` etc.
- **SH**: had `^(STHL1ZZ)$` (no space) but canonical form is `STHL 1ZZ` (with space) → now `^((?:STHL|ASCN|TDCU)\s?1ZZ)$`

All updated regexes accept both spaced and unspaced forms.

## Test plan
- [x] `python3 -m py_compile bin/scripts/sync/import_singleton_territory_postcodes.py`
- [x] All records match their respective country regex
- [x] No `state_id` (country-only)
- [x] No auto-managed fields
- [x] Idempotent merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)