### PR TITLE
feat(postcodes/FO): 117 Faroe Islands postcodes (#1039)

### DIFF
--- a/bin/scripts/sync/import_faroe_islands_postcodes.py
+++ b/bin/scripts/sync/import_faroe_islands_postcodes.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Faroe Islands -> contributions/postcodes/FO.json importer for issue #1039.
+
+Source data
+-----------
+The Faroese Environment Agency (Umhvørvisstovan) publishes the
+official address registry via an ArcGIS REST endpoint. Per
+OpenAddresses' fo/countrywide.json source definition, the layer
+``adressur/us_adr_husanr`` carries 26,301 addresses, each with
+zip + city + municipality.
+
+What this script does
+---------------------
+1. Issues a single ArcGIS REST groupBy query for distinct
+   (zip, city, municipality) tuples — returns 117 unique postcodes.
+2. Resolves state FK by mapping each Faroese kommuna (municipality)
+   to one of CSC's 6 sýslur (regions) via MUNI_TO_ISO2.
+3. Emits one row per postcode with municipality + city as locality.
+4. Writes contributions/postcodes/FO.json idempotently.
+
+Source URL: https://gis.us.fo/arcgis/rest/services/adressur/us_adr_husanr/MapServer/0
+
+State FK strategy
+-----------------
+Source's ``municipality`` field uses the Faroese genitive form
+(e.g. 'Tórshavnar', 'Klaksvíkar'). 22-entry MUNI_TO_ISO2 maps each
+to one of 6 CSC FO regions (sýslur):
+- Streymoy (ST): Tórshavnar, Vestmanna, Kvívíkar, Sunda
+- Eysturoy (EY): Eiðis, Eystur, Runavíkar, Sjóvar, Fuglafjarðar, Nes
+- Sandoy (SA): Sands, Húsavíkar, Skálavíkar, Skopunar, Skúvoyar
+- Vágar (VA): Sørvágs, Vága
+- Northern Isles (NO): Klaksvíkar, Kunoyar, Hvannasunds, Fugloyar,
+  Viðareiðis
+- Suðuroy (SU): Tvøroyrar, Hvalbiar, Fámjins, Vágs, Sumbiar, Hovs,
+  Porkeris
+
+License & attribution
+---------------------
+- Source: Faroese Environment Agency (Umhvørvisstovan)
+- License: Føroyakort terms — free attribution; share-alike: false
+- Each row: ``source: "umhvorvisstovan-fo-arcgis"``
+
+Tier 4 per #1039 license-tier policy (Open Government / NDSAP-style).
+
+Usage
+-----
+    python3 bin/scripts/sync/import_faroe_islands_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://gis.us.fo/arcgis/rest/services/adressur/us_adr_husanr/MapServer/0/query"
+)
+
+# Source municipality (Faroese genitive form) -> CSC iso2.
+MUNI_TO_ISO2: Dict[str, str] = {
+    # Streymoy (ST)
+    "Tórshavnar": "ST",
+    "Vestmanna": "ST",
+    "Kvívíkar": "ST",
+    "Sunda": "ST",
+    # Eysturoy (EY)
+    "Eiðis": "EY",
+    "Eystur": "EY",
+    "Runavíkar": "EY",
+    "Sjóvar": "EY",
+    "Fuglafjarðar": "EY",
+    "Nes": "EY",
+    # Sandoy (SA)
+    "Sands": "SA",
+    "Húsavíkar": "SA",
+    "Skálavíkar": "SA",
+    "Skopunar": "SA",
+    "Skúvoyar": "SA",
+    # Vágar (VA)
+    "Sørvágs": "VA",
+    "Vága": "VA",
+    # Northern Isles (NO)
+    "Klaksvíkar": "NO",
+    "Kunoyar": "NO",
+    "Hvannasunds": "NO",
+    "Fugloyar": "NO",
+    "Viðareiðis": "NO",
+    # Suðuroy (SU)
+    "Tvøroyrar": "SU",
+    "Hvalbiar": "SU",
+    "Fámjins": "SU",
+    "Vágs": "SU",
+    "Sumbiar": "SU",
+    "Hovs": "SU",
+    "Porkeris": "SU",
+}
+
+
+def fetch_distinct_postcodes() -> List[Dict]:
+    """Query ArcGIS REST endpoint for distinct (zip, city, municipality)."""
+    params = {
+        "where": "zip>0",
+        "outFields": "zip,city,municipality",
+        "groupByFieldsForStatistics": "zip,city,municipality",
+        "outStatistics": json.dumps(
+            [
+                {
+                    "statisticType": "count",
+                    "onStatisticField": "objectid",
+                    "outStatisticFieldName": "cnt",
+                }
+            ]
+        ),
+        "f": "json",
+        "resultRecordCount": "2000",
+    }
+    url = f"{SOURCE_URL}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        data = json.loads(r.read())
+    return data.get("features", [])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    print(f"Fetching {SOURCE_URL}")
+    features = fetch_distinct_postcodes()
+    print(f"Source groups: {len(features)}")
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    fo_country = next((c for c in countries if c.get("iso2") == "FO"), None)
+    if fo_country is None:
+        print("ERROR: FO not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(fo_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    fo_states = [s for s in states if s.get("country_id") == fo_country["id"]]
+    state_by_iso2: Dict[str, dict] = {
+        s["iso2"]: s for s in fo_states if s.get("iso2")
+    }
+    print(
+        f"Country: Faroe Islands (id={fo_country['id']}); "
+        f"states indexed: {len(fo_states)}"
+    )
+
+    # Pick first-seen city/muni per zip (groups may have multiple cities per zip)
+    by_zip: Dict[str, Dict] = {}
+    for f in features:
+        a = f.get("attributes", {})
+        z = str(a.get("zip", "")).zfill(3)
+        if not z or z == "000":
+            continue
+        if z in by_zip:
+            continue
+        by_zip[z] = a
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+    unknown_munis: Dict[str, int] = {}
+
+    for code, a in sorted(by_zip.items()):
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+
+        muni = (a.get("municipality") or "").strip()
+        city = (a.get("city") or "").strip()
+        iso2 = MUNI_TO_ISO2.get(muni)
+        state = state_by_iso2.get(iso2) if iso2 else None
+        if state is None:
+            unknown_munis[muni] = unknown_munis.get(muni, 0) + 1
+            skipped_no_state += 1
+
+        # Locality: city, fall back to muni
+        locality = city or muni
+
+        key = (code, locality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(fo_country["id"]),
+            "country_code": "FO",
+        }
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "umhvorvisstovan-fo-arcgis"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Skipped (no state FK): {skipped_no_state:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    if unknown_munis:
+        print("Unknown municipalities (not in MUNI_TO_ISO2):")
+        for m, n in sorted(unknown_munis.items(), key=lambda x: -x[1]):
+            print(f"  {m!r}: {n}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/FO.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/FO.json
+++ b/contributions/postcodes/FO.json
@@ -1,0 +1,1172 @@
+[
+  {
+    "code": "100",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Tórshavn",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "160",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Argir",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "175",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Kirkjubøur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "176",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Velbastaður",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "177",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Syðradalur, Streymoy",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "178",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Norðradalur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "180",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Kaldbak",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "185",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Kaldbaksbotnur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "186",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Sund",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "187",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Hvítanes",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "188",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Hoyvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "210",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5231,
+    "state_code": "SA",
+    "locality_name": "Sandur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "220",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5231,
+    "state_code": "SA",
+    "locality_name": "Skálavík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "230",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5231,
+    "state_code": "SA",
+    "locality_name": "Húsavík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "235",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5231,
+    "state_code": "SA",
+    "locality_name": "Dalur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "236",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5231,
+    "state_code": "SA",
+    "locality_name": "Skarvanes",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "240",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5231,
+    "state_code": "SA",
+    "locality_name": "Skopun",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "260",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5231,
+    "state_code": "SA",
+    "locality_name": "Skúgvoy",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "270",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Nólsoy",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "280",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Hestur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "285",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Koltur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "286",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5231,
+    "state_code": "SA",
+    "locality_name": "Stóra Dímun",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "330",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Stykkið",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "335",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Leynar",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "336",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Skælingur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "340",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Kvívík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "350",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Vestmanna",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "358",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Válur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "360",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5234,
+    "state_code": "VA",
+    "locality_name": "Sandavágur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "370",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5234,
+    "state_code": "VA",
+    "locality_name": "Miðvágur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "380",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5234,
+    "state_code": "VA",
+    "locality_name": "Sørvágur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "385",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5234,
+    "state_code": "VA",
+    "locality_name": "Vatnsoyrar",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "386",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5234,
+    "state_code": "VA",
+    "locality_name": "Bøur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "387",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5234,
+    "state_code": "VA",
+    "locality_name": "Gásadalur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "388",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5234,
+    "state_code": "VA",
+    "locality_name": "Mykines",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "400",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Oyrarbakki",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "410",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Kollafjørður",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "415",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Oyrareingir",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "416",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Signabøur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "420",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Hósvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "430",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Hvalvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "435",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Streymnes",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "436",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Saksun",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "437",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Nesvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "438",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Langasandur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "440",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Haldórsvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "445",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Tjørnuvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "450",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Oyri",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "460",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Norðskáli",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "465",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Svínáir",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "466",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Ljósá",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "470",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Eiði",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "475",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Funningur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "476",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5232,
+    "state_code": "ST",
+    "locality_name": "Gjógv",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "477",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Funningsfjørður",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "478",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Elduvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "480",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Skála",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "485",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Skálafjørður",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "490",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Strendur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "494",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Innan Glyvur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "495",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Kolbeinagjógv",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "496",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Morskranes",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "497",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Selatrað",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "511",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Gøtugjógv",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "512",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Norðragøta",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "513",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Syðrugøta",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "520",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Leirvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "530",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Fuglafjørður",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "600",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Saltangará",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "620",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Runavík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "625",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Glyvrar",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "626",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Lambareiði",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "627",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Lamba",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "640",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Rituvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "645",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Æðuvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "650",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Toftir",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "655",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Nes, Eysturoy",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "656",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Saltnes",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "660",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Søldarfjørður",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "665",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Skipanes",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "666",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Undir Gøtueiði",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "690",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Oyndarfjørður",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "695",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5229,
+    "state_code": "EY",
+    "locality_name": "Hellurnar",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "700",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Klaksvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "725",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Norðoyri",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "726",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Ánirnar",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "727",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Árnafjørður",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "730",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Norðdepil",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "735",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Depil",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "736",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Norðtoftir",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "737",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Múli",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "740",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Hvannasund",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "750",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Viðareiði",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "765",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Svínoy",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "766",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Kirkja",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "767",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Hattarvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "780",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Kunoy",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "785",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Haraldssund",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "795",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Syðradalur, Kalsoy",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "796",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Húsar",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "797",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Mikladalur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "798",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5230,
+    "state_code": "NO",
+    "locality_name": "Trøllanes",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "800",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Tvøroyri",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "825",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Froðba",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "826",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Trongisvágur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "827",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Ørðavík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "850",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Hvalba",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "860",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Sandvík",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "870",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Fámjin",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "900",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Vágur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "925",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Nes, Vágur",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "926",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Lopra",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "927",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Akrar",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "928",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Víkarbyrgi",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "950",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Porkeri",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "960",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Hov",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  },
+  {
+    "code": "970",
+    "country_id": 72,
+    "country_code": "FO",
+    "state_id": 5233,
+    "state_code": "SU",
+    "locality_name": "Sumba",
+    "type": "full",
+    "source": "umhvorvisstovan-fo-arcgis"
+  }
+]


### PR DESCRIPTION
## Summary
- Imports the Faroe Islands' 3-digit postal codes (117 codes) for #1039
- 100% state FK resolution across all 6 sýslur (regions)
- Sourced from Umhvørvisstovan's official ArcGIS REST endpoint

## Source
- **Umhvørvisstovan** (Faroese Environment Agency) — official address registry via ArcGIS REST
- URL: `https://gis.us.fo/arcgis/rest/services/adressur/us_adr_husanr/MapServer/0`
- License: Føroyakort terms — free attribution; share-alike: false (Tier 4 per #1039 policy)

## State FK strategy
22-entry `MUNI_TO_ISO2` maps Faroese kommuna (genitive form) to one of CSC's 6 sýslur:
- **Streymoy (ST)**: Tórshavnar, Vestmanna, Kvívíkar, Sunda
- **Eysturoy (EY)**: Eiðis, Eystur, Runavíkar, Sjóvar, Fuglafjarðar, Nes
- **Sandoy (SA)**: Sands, Húsavíkar, Skálavíkar, Skopunar, Skúvoyar
- **Vágar (VA)**: Sørvágs, Vága
- **Northern Isles (NO)**: Klaksvíkar, Kunoyar, Hvannasunds, Fugloyar, Viðareiðis
- **Suðuroy (SU)**: Tvøroyrar, Hvalbiar, Fámjins, Vágs, Sumbiar, Hovs, Porkeris

## Distribution
| iso2 | region | rows |
|---|---|---|
| ST | Streymoy | 35 |
| EY | Eysturoy | 33 |
| NO | Northern Isles | 19 |
| SU | Suðuroy | 15 |
| SA | Sandoy | 8 |
| VA | Vágar | 7 |

## Pipeline
Single ArcGIS REST `groupBy` query for distinct `(zip, city, municipality)` tuples — yields 117 unique postcodes with municipality FK derivable from source.

## Test plan
- [x] `python3 -m py_compile bin/scripts/sync/import_faroe_islands_postcodes.py`
- [x] All 117 codes match `^(?:FO)*\d{3}$`
- [x] 100% state_id valid; state.country_id == 72; state_code == state.iso2
- [x] No auto-managed fields
- [x] Idempotent merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)