### PR TITLE
feat(postcodes/UY): 1,964 Correo Uruguayo codes (#1039)

### DIFF
--- a/bin/scripts/sync/import_uruguay_postcodes.py
+++ b/bin/scripts/sync/import_uruguay_postcodes.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Uruguay -> contributions/postcodes/UY.json importer for issue #1039.
+
+Source data
+-----------
+The community ``ale-uy/CPuy`` repository (Apache-2.0) ships a SQLite
+database with Uruguay's full Localidades table:
+
+    columns: Departamento (TEXT, uppercase), Localidad (TEXT, uppercase),
+             CodigoPostal (INTEGER, 5-digit)
+
+1,973 (departamento, localidad, código_postal) tuples covering 122
+distinct postcodes across all 19 Uruguayan departments.
+
+Source URL: https://raw.githubusercontent.com/ale-uy/CPuy/master/db
+
+What this script does
+---------------------
+1. Fetches the SQLite db via urllib.
+2. Reads via Python's stdlib sqlite3 (no extra deps).
+3. Resolves state FK by ASCII-fold + name match against CSC's 19
+   UY department entries.
+4. Emits one row per (postcode, locality) tuple.
+5. Writes contributions/postcodes/UY.json idempotently.
+
+Coverage
+--------
+- 1,973 records / 100% state FK
+- All 19 Uruguayan departments covered
+
+License & attribution
+---------------------
+- Source: ale-uy/CPuy (Apache-2.0)
+- Upstream: Correo Uruguayo public lookup
+- Each row: ``source: "correo-uruguayo-via-ale-uy"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_uruguay_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+import tempfile
+import unicodedata
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = "https://raw.githubusercontent.com/ale-uy/CPuy/master/db"
+
+
+def _ascii_fold(value: str) -> str:
+    return (
+        "".join(
+            c
+            for c in unicodedata.normalize("NFKD", value)
+            if not unicodedata.combining(c)
+        )
+        .strip()
+        .lower()
+    )
+
+
+def fetch_bytes(url: str) -> bytes:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.read()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local SQLite (skip fetch)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if args.input:
+        db_path = args.input
+        cleanup = False
+    else:
+        raw = fetch_bytes(SOURCE_URL)
+        print(f"db size: {len(raw):,} bytes")
+        tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        tmp.write(raw)
+        tmp.close()
+        db_path = tmp.name
+        cleanup = True
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    uy_country = next((c for c in countries if c.get("iso2") == "UY"), None)
+    if uy_country is None:
+        print("ERROR: UY not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(uy_country.get("postal_code_regex") or ".*")
+
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    uy_states = [s for s in states if s.get("country_id") == uy_country["id"]]
+    state_by_fold: Dict[str, dict] = {
+        _ascii_fold(s["name"]): s for s in uy_states if s.get("name")
+    }
+    print(
+        f"Country: Uruguay (id={uy_country['id']}); states indexed: {len(uy_states)}"
+    )
+
+    conn = sqlite3.connect(db_path)
+    rows = list(
+        conn.execute("SELECT Departamento, Localidad, CodigoPostal FROM Localidades")
+    )
+    conn.close()
+    if cleanup:
+        os.unlink(db_path)
+    print(f"Source rows: {len(rows):,}")
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    skipped_no_state = 0
+    matched_state = 0
+    unknown_deps: Dict[str, int] = {}
+
+    for dep, loc, cp in rows:
+        code = str(cp).zfill(5)
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+
+        dep_str = (dep or "").strip()
+        loc_str = (loc or "").strip()
+        state = state_by_fold.get(_ascii_fold(dep_str))
+        if state is None:
+            unknown_deps[dep_str] = unknown_deps.get(dep_str, 0) + 1
+            skipped_no_state += 1
+
+        # Title-case the uppercase locality + dept for display
+        locality = loc_str.title()
+        key = (code, locality.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(uy_country["id"]),
+            "country_code": "UY",
+        }
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        if locality:
+            record["locality_name"] = locality
+        record["type"] = "full"
+        record["source"] = "correo-uruguayo-via-ale-uy"
+        records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Skipped (no state FK): {skipped_no_state:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    if unknown_deps:
+        print("Unknown departments:")
+        for d, n in sorted(unknown_deps.items(), key=lambda x: -x[1]):
+            print(f"  {d!r}: {n}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/UY.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/UY.json
+++ b/contributions/postcodes/UY.json
@@ -1,0 +1,19642 @@
+[
+  {
+    "code": "11000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Ciudad Vieja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Puerto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Barrio Sur",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Centro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Cordon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Parque Rodo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Pocitos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Punta Carretas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Malvin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Malvin Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Punta Gorda",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Union",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Carrasco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Carrasco Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Buceo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "La Blanqueada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Larrañaga",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Pque Batlle Villa Dolores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Aires Puros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Atahualpa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Brazo Oriental",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Prado Nueva Savona",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Aguada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Capurro Bella Vista",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Figurita",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Jacinto Vera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "La Comercial",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Reducto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Tres Cruces",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Villa Muñoz Retiro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Belvedere",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "La Teja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Nuevo Paris",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "11900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Tres Ombues Pblo Victoria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Castro Castellanos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Ituzaingo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Mercado Modelo Y Bolivar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Villa Española",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Las Canteras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Maroñas Parque Guarani",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Casavalle",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Cerrito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Las Acacias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Manga",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Piedras Blancas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Colon Sureste Abayuba",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Manga Toledo Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Peñarol Lavalleja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Colon Centro Y Noroeste",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Lezica Melilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Paso De La Arena",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Casabo Pajas Blancas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Cerro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "La Paloma Tomkinson",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Conciliacion",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Paso De Las Duranas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "12900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Sayago",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "13000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Bañados De Carrasco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "13000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Flor De Maroñas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "13000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Jardines Del Hipodromo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "13000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Punta Rieles Bella Italia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "13000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Villa Garcia Manga Rural",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Aeropuerto Internacional De Carrasco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barra De Carrasco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio Obrero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Colonia Nicolich",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "El Bosque",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Empalme Nicolich",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Lago Jardin Del Bosque",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Lagomar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Parque Carrasco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Parque Miramar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso Carrasco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "San Jose De Carrasco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Santa Teresita",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Shangrila",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Fortin De Santa Rosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Marindia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Neptunia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Pinamar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Pinamar Y Pinepark",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Pine Park",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Rincon De Pando",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Salinas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Juana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Atlantida",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "City Golf",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Estacion Atlantida",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "La Chinchilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Las Toscas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Argentina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Bello Horizonte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costa Azul",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Estacion La Floresta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Guazuvira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Guazuvira Nuevo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "La Floresta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Las Vegas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Parque Del Plata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Araminda",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Argentino",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "B.H.U.",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Biarritz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Capilla De Cella",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cuchilla Alta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cuchilla Alta Y El Galeon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "El Galeon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Estacion Piedras De Afilar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Jaureguiberry",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "La Tuna",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Los Titanes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Piedras De Afilar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "San Luis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Santa Ana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Santa Lucia Del Este",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Capitan Juan Antonio Artigas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Colinas De Carrasco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cumbres De Carrasco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Fracc Sobre Ruta 74",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Joaquin Suarez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Quinta Los Horneros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Rincon De Carrasco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Aeroparque",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa El Tato",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cañada Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costa De Pando Olmos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cueva Del Tigre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Dr. Francisco Soca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Empalme Olmos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Estanque De Pando",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Jardines De Pando",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "La Montañesa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "La Palmita",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Las Ranas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Olmos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Pando",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Piedra Del Toro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Piedritas De Suarez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Cañada Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Sosa Diaz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Viejo Molino San Bernardo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio Artigas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio Benzo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio Los Panoramas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio Pretti",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio Santa Rita",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio Traverso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio Villa Murcia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Casarino",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Fracc. Cno. Andaluz Y R.84",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Lomas De Toledo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Los Hornos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Nataly",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Toledo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "San Andres",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Seis Hermanos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Toledo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3218,
+    "state_code": "MO",
+    "locality_name": "Toledo Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Crespo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Fortuna",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Hadita",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Huertos De Toledo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Juanita",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Los Alpes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Marina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Molfino",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Prados De Toledo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa San Felipe",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa San Jose",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Valverde",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Altos De La Tahona",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio San Cristobal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Carmel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Ciudad De La Costa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Colinas De Solymar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "El Bosque De Solymar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "El Pinar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Haras Del Lago",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "La Asuncion",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Las Higueritas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Lomas De Carrasco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Lomas De Solymar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Medanos De Solymar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Montes De Solymar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Parque De Solymar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Pinares De Solymar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Quintas Del Bosque",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Solymar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio Copola",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio La Lucha",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio Remanso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Camino Dodera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Canelon Chico Al Centro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Canelon Chico De Progreso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Colorado Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costa Y Guillamon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cuchilla De Sierra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "El Colorado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "El Dorado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Fracc. Progreso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Instituto Adventista",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "La Paz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Las Piedras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Parada Cabrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso Del Colorado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Poquitos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Progreso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Canelon Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Santos Lugares",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Felicidad",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Foresti",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Paz S.A.",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa San Cono",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "15900",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Vista Linda",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Arenas De Jose Ignacio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Balneario Buenos Aires",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Barra Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Barrio Hipodromo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Barrio Kennedy",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Buenos Aires",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Canteras De Marelli",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Cerro Pelado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Chihuahua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Eden Rock",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "El Chorro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "El Eden",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "El Tesoro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Faro Jose Ignacio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Faro Jose Ignacio Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "La Barra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "La Capuera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "La Juanita",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "La Sonrisa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Lago De Los Cisnes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Laguna Blanca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Laguna Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Las Cumbres",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Los Aromos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Los Corchos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Maldonado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Manantiales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Mataojo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Ocean Park",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Pinares - Las Delicias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Portezuelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Punta Ballena",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Punta Del Este",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Puntas De Mataojo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Puntas De Pan De Azucar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Rincon De Los Sosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Rincon Del Indio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "San Juan Del Este",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "San Rafael - El Placer",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "San Vicente",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Santa Monica",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Sarandi Del Mataojo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Sauce De Portezuelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Villa Delia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Zanja Del Tigre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Barra De Portezuelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Bella Vista",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Colonia J. Suarez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "La Falda",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Las Flores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Las Flores - Estacion",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Piriapolis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Playa Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Playa Hermosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Playa Verde",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Punta Colorada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Punta Negra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "San Francisco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Solis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Cerros Azules",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Gerona",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Gregorio Aznarez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "La Sierra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Nueva Carrara",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Pan De Azucar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Pueblo Solis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Puntas De La Sierra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Ruta 37 Y 9",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Abra De Perdomo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Alfaro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Arroyito De Medina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Carape",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Carlos Cal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Cañada Bellaca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Cañada De La Cruz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Corte De La Leña",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Costas De Jose Ignacio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "El Quijote",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Garzon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Guardia Vieja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Jose Ignacio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Las Cañas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Los Ceibos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Molles De Garzon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Pago De La Paja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Parque Medina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Partido Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Partido Oeste",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Paso De La Cantera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Puntas De Jose Ignacio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Puntas Del Campanera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "San Carlos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Aigua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Alferez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Coronilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Marmaraja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Paso De Los Talas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Paso De Los Troncos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Pororo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Puente De Marmaraja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Salamanca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Sarandi De Aigua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Sauce De Aigua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "20500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Valdivia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "19 De Abril",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Arbolito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Cuchilla De Garzon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "El Canelon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Garzon Abajo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Garzon Al Medio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Garzon Arriba",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "India Muerta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Kilometro 18",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "La Centinela",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "La Ribiera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "La Sierra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Lomas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Los Cerrillos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Paralle",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Paso Doña Rosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Picada Tolosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Puerto De Los Botes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Puntas De Don Carlos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Rocha",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Sarandi De La India Muerta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Sauce De Rocha",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Sierra De Los Rocha",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "18 De Julio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Barra Del Chuy",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Barrancas De La Coronilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Barrio Carpacho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Barrio Pereira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Capacho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Chuy",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Fortin De San Miguel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "La Coronilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "La Fortaleza De Santa Teresa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Los Indios",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Palmares De La Coronilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Puimayen",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Samuel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Aguas Dulces",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Barra De Valizas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Barrio Cardozo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Barrio Torres",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Cabo Polonio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Castillos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Cerro De Los Rocha",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Cerro De Pescadores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "La Esmeralda",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Oratorio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Palmar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Palmar De Castillos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Paso Del Bañado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Plano 291",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Puente Valizas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Punta Del Diablo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Punta Palmar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Rincon De Los Olivera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Rincon De Valizas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Vuelta Del Palmar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Abra De Alferez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Alferez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Barra Isla Negra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Barrio Porvenir",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Cebollati",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Colonia Greissing",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Costas De Cebollati",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Cuchilla Del Arbolito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "El Chimango",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Empalme De Velazquez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Isla Negra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "La Tuna",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Lascano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Los Ajos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Los Talas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Paso De Lopez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Paso Del Ombu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Punta Cebollati",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Quebracho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Rincon De Aparicio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "San Luis Al Medio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Velazquez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Antoniopolis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Arachania",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Balneario Pueblo Nuevo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Costa Azul",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "La Aguada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "La Aguada Y Costa Azul",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "La Pedrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Oceania Del Polonio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Pueblo Nuevo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Puerto La Paloma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Punta Rubia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "San Sebastian",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "San Sebastian De La Pedrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "27400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3216,
+    "state_code": "RO",
+    "locality_name": "Tajamares De La Pedrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Abra De Zabaleta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Arequita",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Arroyo De Los Patos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Arroyo Del Medio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Barra De Los Chanchos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Barrancas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Barriga Negra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Barrio La Coronilla - Ancap",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Blanes Viale",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Campanero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Canteras Del Verdun",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Casupa Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Cerro Pelado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Chamame",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Colon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Consejo Del Niño",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Costa Del Lenguazo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Costas Del Soldado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "El Alto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "El Perdido",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "El Soldado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "El Tigre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Espuelitas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Estacion Andreoni",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Estacion Ortiz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Estacion Solis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Higueritas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "La Cuchilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "La Plata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Ladrillos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Las Achiras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Los Tapes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Manguera Azul",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Marco De Los Reyes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Mariscala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Minas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Molles De Aigua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Ombues De Bentancor",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Ortiz Castro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Paso De Mesa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Piraraja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Polanco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Polanco Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Polanco Sur",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Puntas De Barriga Negra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Puntas De Los Chanchos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Puntas De Polanco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Puntas De San Francisco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Puntas De Santa Lucia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Puntas De Solis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Puntas De Vejigas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Puntas Del Perdido",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Rincon De Mariscala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Rincon De Silva",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Roldan",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "San Francisco De Las Sierras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Santa Lucia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Sierras Blancas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Soldado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Solis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Tapes Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Tapes Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Valle De Solis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Vejigas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Velazquez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Verdun",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Villa Del Rosario",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Villa Serrana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3206,
+    "state_code": "MA",
+    "locality_name": "Abra De Castellanos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Aguas Blancas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Paso Arbelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Sauce De Solis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Solis De Mataojo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "19 De Junio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Alonso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Aramendia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Azucar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Carnales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Corrales De Cebollati",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Costas De Corrales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "El Bellaco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Gutierrez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Jose Pedro Varela",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Maria Albina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Molles De Cañada Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Panteon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Paso Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Retamosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Rincon De Cebollati",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Sarandi De Gutierrez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "30300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Sauce De Corrales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera El Tigre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera Las Palmas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera Los Ceibos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera Mini",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera Zapata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrozal Treinta Y Tres",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Bañado De Oro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Costas Del Sarandi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Cuchilla De Olmos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Paso De Piriz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Siete Casas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "31100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Vergara",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Acosta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrayanes De Cebollati",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrayanes De Corral De Cebollati",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera Bonomo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera Los Teros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera Procipa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera Santa Fe",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Avestruz Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Barrio Abreu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Cañada Chica",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Cañada De Las Piedras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Cañada Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Cerro Pelado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Cerros De Amaro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Cipa Cebollati",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Cipa Olimar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Cipa Secador",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Costas Del Arroyo Malo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Cuchilla De Dionisio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Ejido De Treinta Y Tres",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "El Catete",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Gral. Enrique Martinez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Higuerones",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Julio Maria Sanz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "La Calavera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "La Calera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "La Lata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Las Chacras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Lechiguana De Corrales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Los Ceibos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Maria Isabel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Mate Dulce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Mendizabal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Molles De Olimar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Olimar Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Palo A Pique",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Paso Ancho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Paso De La Laguna",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Poblado Alonzo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Puntas De Leoncho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Puntas De Los Ceibos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Puntas De Quebracho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Puntas Del Oro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Puntas Del Parao",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Rincon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Rincon De Gadea",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Rincon De Iguini",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Rincon De Los Francos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Rincon De Quintana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Sierra Del Yerbal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Treinta Y Tres",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Verde Alto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Villa Passano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Villa Sara",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Yerbal Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "33000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Yerbalito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "34100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Molles Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "34100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Sauce De Olimar Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "34100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Zapican",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "34200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Arrayan",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "34200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Godoy",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "34200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Illescas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "34200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Jose Batlle Y Ordoñez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "34200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Larrosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "34200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Molles Del Pescado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "34200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Nico Perez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "34200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Puntas De Illescas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Las Pavas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Noques De Olimar Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Paso De Averias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Paso De La Atahona",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Pueblo De Los Morochos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Rincon De Urtubey",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Valentines",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Cerro Chato",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "El Carmen",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Arevalo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cuchilla Del Carmen",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Esperanza",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "35300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Santa Clara De Olimar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Laguna Del Junco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Tupambae",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Aguirre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Calera De Recalde",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cerro De Las Cuentas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Coimbra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Fraile Muerto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Ganen",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Las Limas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Los Cerros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Paso De Los Carros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Piñeiro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Puntas De Tacuari",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Quebracho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Rincon De Contreras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Rincon De La Urbana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Rincon De Py",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Rincon De Suarez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Sanchez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Toledo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Tres Islas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "36200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Wenceslao Silvera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Acegua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Amarillo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Arachania",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Arbolito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Asperezas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Barrio La Vinchuca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Barrio Lopez Benitez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Bañado De Medina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Berachi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Buena Vista",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Campamento",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Casa De Las Cronicas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Caserio Las Cañas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cañada Sarandi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cañitas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cementerio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Centurion",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Chacras De Melo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Colonia Ceres",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Colonia Maria Teresa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Colonia Orozco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Conventos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Corral De Piedra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cruz De Piedra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cuchilla Cambota",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cuchilla De Melo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cuchilla Del Paraiso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cuchilla Peralta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Duraznero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Escuela De Agronomia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Falda De Sierra De Los Rios",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Granja De Acegua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Granja Pallero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Guazunambi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Hipodromo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Infiernillo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Isidoro Noblia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "La Gloria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "La Micaela",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "La Mina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "La Pedrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Mangrullo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Maria Isabel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Mazangano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Melo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Minuano De Acegua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Misterio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Montecito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Nando",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Panteon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Paso De La Cruz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Paso De Las Tropas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Paso De Las Yeguas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Paso Melo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Peñarol",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Puente Negro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Puntas De Amarillo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Puntas De La Mina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Puntas De Molles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Puntas De Palleros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Ramon Trigo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Rincon De Los Coroneles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Rincon De Paiva",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Rincon De Tacuari",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Rodriguez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Saldañas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "San Diego",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Santa Teresa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Sarandi De Acegua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Sauce De Conventos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Soto Goro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Tres Boliches",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Villa Viñoles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Ñangapire",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera La Catumbera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera La Querencia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera Rincon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Arrocera San Fernando",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Arroyo Malo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Arrozal Cesarone",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Arrozal Rosales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Barra Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Barra Del Tacuari",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Bañado De Las Pajas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cañada De Santos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cañada Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3214,
+    "state_code": "TT",
+    "locality_name": "Costas De Tacuari",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Garao",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "La Coronilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Lago Merin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Picada De Maya",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Picada De Salome",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Placido Rosas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Poblado Uruguay",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Presidente Doctor Getulio Vargas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Puntas Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Rincon De Los Olivera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Rio Branco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "San Servando",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Sarandi De Barcelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Sarandi De Yaguaron",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "37100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Uruguay",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Arroyo Sauzal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Ataques",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Barra De Ataques",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Barrio Recreo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Batovi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Bañado Del Chaja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Capon Alto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cerrillada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cerro Caqueiro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cerro Chapeu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cerro Solito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cruz De San Pedro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cuchilla De Tres Cerros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cuchilla Mangueras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Curticeiras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Guaviyu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "La Caillava",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "La Pedrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Lagos Del Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Lagunon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Mandubi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso Ataques",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso Del Lagunon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso Del Tapado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso Lapuente",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso Serpa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Platon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Puntas De Corrales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Puntas De Cuñapiru",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Puntas Del Yaguari",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Rivera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Santa Isabel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Santa Teresa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Sauce De Batovi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Tres Cruces",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Tres Puentes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Villa Indart",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Yaguari",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Buena Union",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cerro Alegre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "La Palma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Los Potreros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Lunarejo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Parada Medina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso De Ataques",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso De La Arena",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso De La Calera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Piedras Blancas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Puntas Del Sauzal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Rincon De Moraes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Sauzal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Tranqueras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Zanja Honda De Tranqueras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Limite Contestado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "40200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Masoller",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Berruti",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Blanquillos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Buena Orden Al Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Carpinteria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cerro Blanco De Cuñapiru",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cerro Pelado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cerro Pelado Al Este",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cerros De La Calera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Coronilla De Corrales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Costas De Cuñapiru",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cuchilla De Yaguari",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Curtume",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cuñapiru",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "La Calera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Las Flores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Laureles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Minas De Corrales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Minas De Cuñapiru (Usinas)",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Minas De Zapucay",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso Casildo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Rincon De Los Castillos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Rincon De Roland",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "San Gregorio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Santa Ernestina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Segarra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Abrojal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Alborada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Amarillo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Arroyo Blanco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Caraguata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cerro Chato",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Cerros Blancos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Chirca De Caraguata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Coronilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "El Ceibo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "El Palmito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Hospital",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "La Cerrillada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "La Chilca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Moirones",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso Amarillo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso De Arriera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso De Frontera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso Del Puerto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Pueblo De Los Santos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Pueblo Socorro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Puntas De Abrojal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Rincon De Amarillo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Rincon De Rodriguez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Rincon De Yaguari",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Vichadero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "41200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Zanja Honda",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Achar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Arroyo Del Medio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Ataque",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Balneario Ipora",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Barrio La Matutina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Barrio Libertad",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Barrio Lopez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Barrio Santangelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Barrio Torres",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Bañado De Cañas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Bañado De Rocha",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Blanquillos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Caraguata Al Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cañas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cerro Batovi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cerro De Pastoreo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cerro De Pereira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cerro Del Arbolito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cerros De Clara",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Charata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cinco Sauces",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Clara",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Clavijo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Colman",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Costas De Caraguata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Costas De Tres Cruces",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Coyo Martinez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cruz De Los Caminos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cuchilla De La Casa De Piedra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cuchilla De La Palma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cuchilla De Laureles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cuchilla Del Ombu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Curtina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "El Empalme",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Frigorifico Modelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Heriberto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "La Aldea",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "La Bolsa 01",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "La Bolsa 02",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "La Hilera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "La Palma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "La Pedrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Lambare",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Larrayos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Las Arenas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Las Chircas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Las Pajas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Las Toscas De Caraguata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Laura",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Laureles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Coitinhos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Cuadrados",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Feos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Furtados",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Garcia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Gomez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Malavares",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Ortices",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Rodriguez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Rosanos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Rosas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Semper",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Vazquez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Manuel Diaz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Martinote",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Minuano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Montevideo Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Once Cerros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Pampa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso Bonilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso De Ceferino",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Paso De Gaire",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso De Las Carretas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso De Las Flores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso De Las Toscas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso De Los Novillos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso De Perez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso Del Cerro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso Del Medio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso Hondo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso Livindo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Paso Pereira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso Victor",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Picada De Cuello",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Piedra Alta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Piedra Sola",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Pueblo Clavijo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Pueblo De Arriba",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Pueblo Del Barro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Punta De Carretera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Puntas De Cinco Sauces",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Rincon De Diniz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Rincon De Freitas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Rincon De Giloca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Rincon De La Aldea",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Rincon De La Bolsa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Rincon De La Laguna",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Rincon De Los Machado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Rincon De Pereira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Rincon De Tres Cerros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Rincon De Zamora",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Rivera Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "San Joaquin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Sauce De Batovi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Sauce De Tranqueras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Sauce Solo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Sauce Solo Del Rio Negro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Tacuarembo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Tacuarembo Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Tambores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Tierras Coloradas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3207,
+    "state_code": "RV",
+    "locality_name": "Tres Cerros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Tres Guitarras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Turupi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Valle Eden",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Villa Ansina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Zambullon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Zapara",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Zapucay",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cardoso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cardozo Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Chamberlain",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Churchill",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cuchilla De Peralta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "El Progreso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Estacion Francia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Estacion Menendez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Isla De Arguelles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "La Coronilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "La Palma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Molles Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Parada Sur",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Parish",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Paso De Los Toros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Paso De Soca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Pueblo Centenario",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Rincon Del Bonete",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Rolon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Santa Rosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Sarandi De La China",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Sarandi De Navarro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Carpinteria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cañada Del Estado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Cerro Chato",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Cerros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Los Laureles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "Puntas De Laureles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "San Benito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "45200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3221,
+    "state_code": "TA",
+    "locality_name": "San Gregorio De Polanco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Arenitas Blancas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Balneario Albisu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Bella Vista",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Biassini",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Bordenave",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Campo De Todos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Carumbe",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Celeste",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Cerrillada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Cerrilladas De Saucedo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Cerro Chato",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Cerros De Vera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Chapicuy",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Colonia 18 De Julio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Colonia Itapebi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Colonia Lavalleja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Colonia Osimani",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Colonia Rubio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Corral De Piedra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Corralito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Cuchilla De Guaviyu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Cuchilla Del Salto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "El Mellado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Ferreira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Garibaldi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Guaviyu De Arapey",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Itapebi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "La Bolsa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "La Bolsa 02",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "La Bolsa 03",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "La Caballada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "La Viticola",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Las Flores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Laureles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Lluveras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Los Orientales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Mataojito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Mataojo Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Nueva Hesperides",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Olivera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Osimani Y Llerena",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Palomas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Parada Dayman",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Parada Herreria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Parque Jose Luis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Paso  Valega",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Paso Cementerio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Paso De Las Piedras De Arerungua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Paso Del Parque Del Dayman",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Paso Del Potrero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Paso Del Tapado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Paso Fialho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Paso Nuevo Del Arapey",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Pepe Nuñez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Pueblo Cayetano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Pueblo Farias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Pueblo Fernandez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Pueblo Quintana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Pueblo Ramos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Puntas De Valentin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Rincon De Valentin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Russo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Salto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "San Mauricio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Sarandi De Arapey",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Sauce Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Saucedo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Sopas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Talas De Itapebi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Termas Del Arapey",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Termas Del Dayman",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Tomas Paz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Toro Negro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Tropezon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Tropiezo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Valentin Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Zanja De Alcain",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Zanja Del Tigre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Chacras De Constitucion",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Constitucion",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "El Espinillar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Belen",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Chacras De Belen",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Sarandi De Yacuy",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "50200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3220,
+    "state_code": "SA",
+    "locality_name": "Yacuy",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Artigas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Baltasar Brum",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Bernabe Rivera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Camaño",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Catalan Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Catalan Volcan",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Cerrito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Cerro Ejido",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Cerro San Eugenio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Cerro Signorelli",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Chiflero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Colonia Jose Artigas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Colonia Pintado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Cuaro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Diego Lamas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Estiba",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Fagundez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Guyubira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Javier De Viana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "La Bolsa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Meneses",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Paguero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Palma Sola",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Paso Campamento",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Paso De Leon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Paso De Ramos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Paso Farias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Patitas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Piedra Pintada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Pintadito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Pintado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Pintado Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Rincon De Pacheco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Sarandi De Cuaro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Sequeira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Tamandua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Taruman",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Topador",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Zanja Aruera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Bella Union",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Cainsa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Cainza Campo 3",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Calnu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Colonia España",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Colonia Estrella",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Colonia Palma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Colonia Viñar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Coronado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Cuareim",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Franquia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Las Piedras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Lenguazo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Mones Quintela",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Paredon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Paso De La Cruz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Port. De Hierro Y Campodonico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "55100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3205,
+    "state_code": "AR",
+    "locality_name": "Tomas Gomensoro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Al Sur De Arroyo Sacra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Araujo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Arroyo Negro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Cangue",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Carumbe",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Casa Blanca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Cañada Del Pueblo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Cerro Chato",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Chacras De Paysandu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Chacras De Paysandu Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Chacras De Paysandu Sur",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Colonia Cangue",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Colonia Las Delicias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Colonia Paysandu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Colonia Uruguaya",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Constancia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Costa De Sacra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Cuchilla De Buricayupi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Cuchilla San Jose",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "El Chaco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "El Duraznal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "El Eucaliptus",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "El Horno",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "El Tarugo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Estacion Porvenir",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Etchemendi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Gallinal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Guayabos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "La Lata Ruta 3 (Km. 375)",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "La Paz (Ruta 3 Km. 346)",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "La Tentacion",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Las Palmas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Lorenzo Geyres",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Molles Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Nuevo Paysandu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Orgoroso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Parada Pandule",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Paso De Los Carros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Paysandu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Perico Moreno",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Porvenir",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Pueblo Esperanza",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Pueblo Federacion",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Puntas De Bacacua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Puntas De Buricayupi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Puntas De Cangue",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Puntas De Gualeguay",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Puntas De Las Isletas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Queguay Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Queguayar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Rabon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "San Felix",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "San Francisco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "San Miguel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Santa Elisa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Sauce De Abajo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Sauce Del Buricayupi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Sauce Del Queguay",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Soto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Tres Bocas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Uleste",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Valdez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Zeballos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Arbolito (Totoral)",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Beisso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Colonia Juncal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Cuchilla De Fuego",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Guichon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Los Mellizos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Merinos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Morato (Tres Arboles)",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Palmar Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Piñera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Pueblo Alonzo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Puntas De Averias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Termas De Almiron",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Villa Maria (Tiatucura)",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Arroyo Malo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Colonia Arroyo Malo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Colonia Santa Blanca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Guaviyu De Quebracho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Palmar Del Quebracho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Parada Rivas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Quebracho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Santa Kilda",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Termas De Guaviyu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Arroyo Negro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Las Flores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Piedras Coloradas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3212,
+    "state_code": "PA",
+    "locality_name": "Puntas De Arroyo Negro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "60400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Algorta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "61100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "San Javier",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "61100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Tres Quintas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Barrio Anglo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Caracoles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Cañitas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "El Abrojal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Fray Bentos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Las Cañas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Las Fracciones",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Las Margaritas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Los Ranchos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Nuevo Berlin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Ombucitos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Porton Haedo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Pte. San Martin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "San Lorenzo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Yaguarete",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Bellaco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Colonia El Ombu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Colonia John F. Kennedy",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Don Esteban",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "El Surco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Estancia Vichadero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "La Florida",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "La Union",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Las Flores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Mataojo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Menafra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Molles De Porrua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Palmar De Porrua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Paso De Balbuena",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Paso De Leopoldo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Paso De Los Cobres",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Pauru",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Pueblo Grecco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Sanchez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Sanchez Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Santa Isabel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Sarandi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Tres Bocas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Valle De Soba",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Villa General Borges",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Villa Maria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "65100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Young",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Artilleros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Cerros De San Juan",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Colonia Del Sacramento",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Conchillas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "El Bañado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "El Caño",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "El Ensueño",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "El General",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "El Quinton",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "El Semillero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Estacion Experimental \"La Estanzuela\"",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Estancia Anchorena",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Juan Carlos Caseros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "La Estanzuela",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "La Horqueta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Laguna De Los Patos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Martin Chico De Conchillas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Minas De Narancio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Piedra De Los Indios",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Puerto Ingles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Puerto Platero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Punta Francesa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Puntas De San Pedro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Quinton",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Radial Hernandez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Real De Vera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Reducto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Riachuelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "San Pedro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "San Pedro De Arriba",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "San Pedro Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Santa Ana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Santa Rosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Buena Hora",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Carmelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Caserio El Cerro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Castillos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Cerro Carmelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Colonia Arrue",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Colonia Estrella",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Costa De Vacas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Costas De Juan Gonzalez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Curupi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "El Cerro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "El Chileno",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "El Faro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Juan Gonzalez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Lares",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Lomas De Carmelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Martin Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Perseverano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Viboras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Viboras Y Vacas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Zagarzazu",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Barker",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Barker Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Colonia Peirano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Colonia Talice",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Costa De Colla Al Este",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Costa Del Navarro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Costas De Polonia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "La Paz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Media Agua",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Minuano Y Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Paso Morlan",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Paso Quicho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Pastoreo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Puerto Concordia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Puerto Rosario",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Puntas Del Rosario",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Radial Rosario",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Rosario",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Rosario Y Colla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Terminal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Tres Esquinas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Barrancas Coloradas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Barrio Mendaña",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Barrio Olimpico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Blanca Arena",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Boca Del Rosario",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Bonjour",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Brisas Del Plata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Campamento Artigas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Cerros Negros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Colonia Española",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Colonia Quevedo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Concordia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Costa De Rosario",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Cufre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "La Sierra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Los Pinos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Nueva Helvecia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Paso De La Quinta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Picada De Benitez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Playa Azul",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Playa Britopolis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Playa Fomento",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Playa Parant",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Resguardo Cufre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Rincon Del Rey",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Santa Regina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Chico Torino",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Colonia Valdense",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Arrivillaga",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Boca Del Rosario Oeste",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Colonia Cosmopolita",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Juan Lacaze",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Paraje Minuano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Tomas Bell",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Villa Pancha",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Costa De Tarariras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Paso Antolin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Paso Hospital",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Puntas De Melo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Puntas Del Riachuelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Puntas Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "San Juan",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "San Luis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "San Luis De Tarariras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "San Luis Sanchez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Tarariras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Agraciada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Belgrano Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Belgrano Sur",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Las Flores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Nueva Palmira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Polancos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Puntas De Arenales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Villa Alejandrina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Campana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Cerro De Las Armas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Colonia Miguelete",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Colonia Sarandi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Costas De San Juan",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "El Cuadro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Gil",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Las Chispas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Manantiales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Miguelete De Conchillas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Molles De Miguelete",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Ombues De Lavalle",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Paso Hospital Manantiales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Piedras Blancas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Puntas De Juan Gonzalez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Puntas De San Juan",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "San Roque",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "70800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Sarandi Campana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Asencio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Azotea De Vera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Bequelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Cerro Alegre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Cerro Vera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Chacras De Mercedes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Cololo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Colonia Diaz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "El Tala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Grito De Asencio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "La Tabla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "Los Arrayanes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Mercedes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Palmar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Progreso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Rincon De Cololo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "San Dios",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Santa Blanca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Sarandi Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Unidad Cooperaria No 1",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Villa Darwin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Arenal Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Bizcocho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Buena Vista",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Cañada Magallanes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Cañada Nieto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Cañada Paraguaya",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Chacras De Dolores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Colonia Concordia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Corralito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Costa Del Aguila",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Cuatro Bocas De Buena Vista",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Dolores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Espinillo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "La Concordia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "La Loma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "La Palma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Las Maulas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Maciel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Palo Solo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Paso De La Arena",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Paso De Ramos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Rincon De Cañada Nieto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Rincon De Ruiz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Villa Soriano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Altos Del Perdido",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Arroyo Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Bajos Del Perdido",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Cardona",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Colonia Larrañaga",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Colonia Santa Clara",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Colonia Uruguaya",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Costas Del Perdido",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Cuchilla Del Perdido",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Cueva Del Tigre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Duraznito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Egaña",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Florencio Sanchez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Juan Jackson",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "La Laguna",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Lata Del Perdido",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Monzon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Paso Birriel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Piedra Chata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Puntas De San Salvador",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Puntas Del Tala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Risso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3208,
+    "state_code": "CO",
+    "locality_name": "Zunin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Arroyo Del Medio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Santa Catalina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Zanja Honda",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Cuchilla Del Corralito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Jose Enrique Rodo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Parada Suarez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Puntas De Durazno",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "San Martin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Coquimbo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "El Aguila",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Garula",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Olivera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Palmitas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "75500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3219,
+    "state_code": "SO",
+    "locality_name": "Pedro Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Arroyo De La Virgen",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Arroyo Llano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Bañado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Bella Vista",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Cagancha Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Carreta Quemada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Cañada Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Chamizo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Colonia America",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Coronilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Costas Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Cruz De Los Caminos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Cuchilla De Pereira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Cuchilla Seca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Escudero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Fajardo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Fajina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Gonzalez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Jesus Maria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Juan Soler",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Juncal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "La Casilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Laurel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Mahoma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Mal Abrigo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Mundo Azul",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Mundo Azul Aguirre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Pachina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Panta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Pantanoso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Paso De Cames",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Paso De Mas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Paso Del Carreton",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Paso Del Rey",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Pavon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Perico Perez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Puntas De Cagancha",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Puntas De Cañada Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Puntas De Chamizo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Puntas De Gregorio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Puntas De Laurel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Raigon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Rincon De Arias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Rincon De Nazareth",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Rincon Del Pino",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Rocho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "San Gregorio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "San Jose De Mayo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Tabarez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Tala De Pereira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Tranquera Colorada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Villa Maria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Zanja Honda",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Cololo Tinosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Colonia Italia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Colonia Juan Maria Perez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Costa Del Mauricio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Kiyu - Ordeig",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Libertad",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Orillas Del Plata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Puntas De Tropa Vieja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Puntas De Valdez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Radial Ruta 3",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Rincon De Buschental",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Sauce Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Valdez Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Colonia Fernandez Crespo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Colonia San Joaquin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Costas De Pereira",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Mangrullo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Paso De Las Piedras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Rafael Perazza",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Boca Del Cufre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Colonia Delta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Ecilda Paullier",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "La Boyada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Picada Gambetta",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Rincon De Arazati",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Rincon De Cufre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Scavino",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Cagancha",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Cuchilla Del Vichadero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Estacion Rodriguez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "La Cuchilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Rincon De La Torre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Tropezon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Autodromo Nacional",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Ceramicas Del Sur",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Ciudad Del Plata",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Colonia Wilson",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Delta El Tigre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Monte Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Parque Postel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Parque Postel Cnel. Adrian Medina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Penino",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Playa Pascual",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Rincon De La Bolsa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Safici",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "San Fernando",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "San Fernando Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Santa Monica",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Tropas Viejas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Villa Olimpica",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "80500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Villa Rives",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Andresito",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Arenal Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Arenal Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Arroyo Malo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Cañada Amilivia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Cerro Colorado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Chacras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Chacras De Borghi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Colonia Alemana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Costas De San Jose",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Costas Del Tala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Cuchilla De Villasboas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "El Coronilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "El Totoral",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Ferrizo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Guaycuru",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Ismael Cortinas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Juan Jose Castro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "La Alianza",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "La Casilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "La Guardia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Los Puentes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Marincho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Paso  De Lugo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Paso Del Guaycuru",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Paso Hondo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Pueblo Pintos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Puntas De Chamanga",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Puntas De Marincho",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Puntas De San Jose",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Puntas De Sarandi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Puntas Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Rincon Del Palacio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "San Gregorio De Flores",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Santa Adelaida",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Sarandi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Trinidad",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Villa Pastora",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "85000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Villasboas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Camino De La Cadena",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Canelon Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Canelon Grande De Pacheco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Canelones",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Echevarria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Empalme Dogliotti",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Juanico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "La Paloma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Las Violetas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Mataojo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Melgarejo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Murialdo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso De Cuello",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso De Las Toscas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso Del Medio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso Espinosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso Palomeque",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Rincon Del Gigante",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Arejo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrancas Coloradas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Camino Lloveras",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Campo Militar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cerrillos Al Oeste",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cerrillos Al Sur",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Colorado Y Brujas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Esquina Gonzalez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Las Brujas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Los Cerrillos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Melilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Parador Tajes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso Del Bote",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puente De Brujas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Brujas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Rincon De Portezuelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Rincon Del Colorado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Sofia Santos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Encantada",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "18 De Julio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Aguas Corrientes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Capurro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cañada De Montaño",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Colonia Dr. Bernardo Etchepare",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cuchilla Verde",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Ituzaingo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Los Ceibos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Margat",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Paso Belastiqui",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso De Los Alamos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso De Los Francos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso De Pache",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso Del Sordo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3204,
+    "state_code": "SJ",
+    "locality_name": "Rincon De Albano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Rincon De Velazquez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Rincon De Vidal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "90200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Santa Lucia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cañada Prudencio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costa Del Tala Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Rincon Del Conde",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "San Ramon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Vejigas De San Ramon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Vejigas De Tala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Arenal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costa De Pando San Bautista",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costa Del Tala Este",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costas Del Colorado Este",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "El Colorado San Bautista",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "El Cuadro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso De Los Difuntos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Pueblo Castellanos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Cochengo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Las Violetas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "San Bautista",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barra Del Tala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Canelon Grande Norte",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cañada Cardozo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costas Del Colorado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costas Del Tala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso De La Cadena",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Cañada Cardozo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "San Antonio",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Canelon Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costa De Pando San Jacinto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costa Del Pantanoso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso De La Paloma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Pantanoso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Pantanoso Este",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Santa Rosa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barrio Del Libertador",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Blanco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Carrasco Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costa Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cruz De Los Caminos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cuchilla De Machin",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cuchilla De Rocha",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Empalme Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Mata Siete",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Pantanoso",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Pantanoso Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Ponce Mata Siete",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Mata Siete",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Rancherios De Ponce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "San Pedro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Totoral Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Villa Nueva",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Barra De La Pedrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cochengo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costa De Pando",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costas De Solis",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Estacion Pedrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Estacion Tapia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Piedra Sola",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Pedrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "San Jacinto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Talita",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cuchilla Cabo De Hornos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Cuchilla De Zeballos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "El Colorado De Migues",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Estacion Migues",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "La Totora",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Migues",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Montes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Pedernal Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas Del Arenal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Sarandi De Migues",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Sauce Solo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Sauce Solo De Migues",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Sauce Solo De Montes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Solis Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Solis Chico De Migues",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91700",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Solis Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costas De Pedernal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Feliciano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Macana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Nutrias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso De La Salamanca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Paso Rivero De Vejigas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Pedernal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Pedernal Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Piedritas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Puntas De Vejigas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Tala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "91800",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Vejigas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Berrondo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Candil",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Cerro De La Macana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Cerros De Florida",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Chacras De Florida",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Chacras Del Pintado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Colonia Sanchez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costa De Arias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costa De La Cruz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costas De Arias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costas Del Pintado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Dr. A. Gallinal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Florida",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Hernandarias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Juncal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "La Cruz",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "La Macana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Las Piedritas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Molles Del Timote",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Palermo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Pantanoso De Castro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Paso Calleros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Puntas De Calleros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "San Gabriel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "San Geronimo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "San Juan",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "San Pedro De Timote",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Santa Teresa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Tala De Castro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Talita",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Tornero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Urioste",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Villa Vieja",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Ahogados",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Arroyo De Los Negros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Calleri",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Caserio La Fundacion",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Corral De Piedra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costa De Parana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costa Del Tala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costas De Maciel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Cuchilla Santo Domingo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "La Cimbra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Piedras Coloradas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Pintado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Polanco Del Yi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Puntas De Maciel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Puntas De Sarandi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Puntas De Sauce De Maciel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Puntas Del Corral De Piedra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Sarandi Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Sauce De Maciel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Tala De Maciel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "Talas De Maciel",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "94100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Villa Hipica",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "25 De Mayo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Paso De Los Novillos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Paso Vela",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Cardal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costas De Santa Lucia Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Independencia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "25 De Agosto",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Arroyo Pelado",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Mendoza Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Puente De Mendoza",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Rincon De Vignoli",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "95600",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Mendoza Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Chamizo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Chamizo Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Colonia Treinta Y Tres Orientales",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costas De Chamizo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96100",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costas Del Santa Lucia Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Arroyo Chamizo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Arroyo Latorre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Bolivar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costas De Chamizo Grande",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3213,
+    "state_code": "CA",
+    "locality_name": "Costas De Santa Lucia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Fray Marcos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "La Escobilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Puntas De La Escobilla",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96200",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Puntas Del Arroyo Latorre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Casupa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costas Del Amarillo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3215,
+    "state_code": "LA",
+    "locality_name": "Gaetan (Cuchilla De Carbajal)",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Puntas De Chamizo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96300",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Vignoli",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Piedra Campana",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96400",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Reboledo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Alejandro Gallinal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Arteaga",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Paso Real De Mansavillagra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Puntas De Chamame",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "96500",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Puntas De Mansavillagra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Abella",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Aguas Buenas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Arroyo De Los Perros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Barrancas Coloradas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Barrio Duran",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Batovi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Baygorria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Blanquillo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Blanquillo Al Oeste",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Caballero",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Capilla De Farruco",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Carlos Reyles",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3211,
+    "state_code": "CL",
+    "locality_name": "Cañada Brava",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Ceibal",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Cerrezuelo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Cerro Convento",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Chacras De Durazno",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Chileno",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Chileno Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Chileno Grande (Aguero)",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Costa De Cuadra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Cuchilla De Ramirez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Cuchilla Del Rincon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Durazno",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Estacion Chileno",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Feliciano",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Fonseca",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Goñi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Higueras De Carpinteria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "La Alegria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3210,
+    "state_code": "RN",
+    "locality_name": "La Arena",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3203,
+    "state_code": "FS",
+    "locality_name": "La Cordobesa",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "La Mazamorra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "La Paloma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Las Acacias",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Las Cañas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Las Palmas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Las Tunas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Los Agregados",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Los Tapes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Maestre Campo",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Maria Cejas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Mariscala Del Carmen",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Molles De Quinteros",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Mouriño",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Municipio De Durazno",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Ombues De Oribe",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Paso Ramirez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Paso Real De Carpinteria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Paso Tejera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Pueblo De Alvarez",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Puglia",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Puntas De Carpinteria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Rincon De Cuadra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Rincon De Los Camilos",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Rincon De Los Tapes",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Rolon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Salinas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Salinas Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "San Jorge",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "San Jose De Las Cañas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Sandu Chico",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Santa Bernardina",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Sarandi De Rio Negro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Sauce De Herrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Sauce De Villanueva",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Sauce Del Yi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Tejera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Verdun",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Villa Del Carmen",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "97000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Villasboas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Arroyo Monzon",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Barra Molles Del Timote",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Barra Sauce De Mansavillagra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Capilla Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Chilcas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Chingolas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Costa De Illescas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "De Dios",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Elias Regules",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Estacion Capilla Del Sauce",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Ferrer",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "La Palma",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "La Victoria",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Malbajar Este",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Malbajar Oeste",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Mansavillagra",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Mariscala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Montecoral",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Paso De Aguirre",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Paso De Castro",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Paso Del Medio Las Palmas",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Puntas De Herrera",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Puntas De Malbajar",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Rincon Sauce Del Yi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Rossell Y Rius",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Santa Clara",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Sarandi Del Yi",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3217,
+    "state_code": "FD",
+    "locality_name": "Tabare",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  },
+  {
+    "code": "98000",
+    "country_id": 235,
+    "country_code": "UY",
+    "state_id": 3209,
+    "state_code": "DU",
+    "locality_name": "Tala De Mariscala",
+    "type": "full",
+    "source": "correo-uruguayo-via-ale-uy"
+  }
+]


### PR DESCRIPTION
## Summary
- Imports Uruguay's 5-digit postcodes (1,964 records) for #1039
- 100% state FK resolution across all 19 CSC UY departments

## Source
- [`ale-uy/CPuy`](https://github.com/ale-uy/CPuy) — Apache-2.0
- File: `db` (SQLite, 151 KB)
- Upstream: Correo Uruguayo public lookup

## State FK strategy
ASCII-fold + name match against CSC UY states. All 19 source departments match CSC names verbatim under NFKD fold (handles `PAYSANDU` → Paysandú, `RIO NEGRO` → Río Negro, etc.).

## Pipeline
1. Fetch SQLite db via urllib (151 KB)
2. Parse with stdlib `sqlite3` (no extra deps)
3. Title-case uppercase locality names for display

## Distribution (top 5)
| iso2 | department | rows |
|---|---|---|
| CA | Canelones | 291 |
| CO | Colonia | 147 |
| TA | Tacuarembó | 126 |
| CL | Cerro Largo | 125 |
| SJ | San José | 113 |

All 19 departments covered.

## Test plan
- [x] `python3 -m py_compile bin/scripts/sync/import_uruguay_postcodes.py`
- [x] All 1,964 codes match `^\d{5}$`
- [x] 100% state_id valid; state.country_id == 235; state_code == state.iso2
- [x] No auto-managed fields
- [x] Idempotent merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)