### PR TITLE
feat(postcodes): 54 Caribbean postcodes — KY,BB,TT (#1039)

### DIFF
--- a/bin/scripts/sync/import_caribbean_postcodes.py
+++ b/bin/scripts/sync/import_caribbean_postcodes.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""KY + BB + TT Caribbean postcodes for issue #1039.
+
+Source data
+-----------
+The community ``usama216/shipping-market`` Laravel seeder
+``CaribbeanLocationSeeder.php`` ships hand-curated parish/district
++ postal-code data for 22 Caribbean territories. This importer
+extracts the three with non-null CSC ``postal_code_regex``:
+
+    KY Cayman Islands     (KY#-#### format, 3 islands)
+    BB Barbados           (BB##### format, 11 parishes)
+    TT Trinidad & Tobago  (6-digit format, 15 administrative areas)
+
+Source URL: https://raw.githubusercontent.com/usama216/shipping-market/
+            main/database/seeders/CaribbeanLocationSeeder.php
+
+What this script does
+---------------------
+1. Fetches the PHP seeder via urllib.
+2. Walks each block delimited by ``// COUNTRY (XX) - Has postal codes``,
+   then for each parish/district reads ``'City' => ['postal_code' =>
+   '<code>']`` literals via regex.
+3. Resolves CSC state FK by NAME match (TT has divergent iso2 codes
+   in the seeder vs CSC; name match handles both).
+4. Writes contributions/postcodes/{KY,BB,TT}.json idempotently.
+
+Coverage
+--------
+- KY: 9 codes across 3 islands (~half of Cayman Post's published
+  codes; covers the main settlement of each island).
+- BB: ~20 codes across 11 parishes (Bridgetown, Holetown,
+  Speightstown + parish capitals).
+- TT: ~30 codes across 15 administrative areas (Port of Spain,
+  San Fernando, Tobago + each region's capital).
+
+Total: ~50 codes — small but covers the population centers of three
+territories that previously had no #1039 coverage.
+
+License & attribution
+---------------------
+- Source repo (``usama216/shipping-market``) ships **without a formal
+  license**. Per CSC's #1039 source-class taxonomy this is Tier 5:
+  acceptable for facts-only redistribution with explicit attribution.
+- Postal codes themselves are factual data published by the
+  respective national postal authorities (Cayman Post, Barbados
+  Postal Service, TTPost) and are not copyrightable.
+- Each row carries ``source: "shipping-market-caribbean-seeder"``
+  for export-time provenance.
+
+Usage
+-----
+    python3 bin/scripts/sync/import_caribbean_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import unicodedata
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/usama216/shipping-market/"
+    "main/database/seeders/CaribbeanLocationSeeder.php"
+)
+
+TARGETS = ("KY", "BB", "TT")
+
+# Per-country aliases: seeder parish/region label -> CSC state name.
+# Reasons:
+#  TT 'Mayaro-Rio Claro': CSC orders the compound name as
+#    'Rio Claro-Mayaro' (id=MRC).
+STATE_NAME_ALIASES: Dict[str, Dict[str, str]] = {
+    "TT": {"Mayaro-Rio Claro": "Rio Claro-Mayaro"},
+}
+
+
+def fetch_text(url: str) -> str:
+    """Fetch a text resource via urllib with a timeout."""
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return r.read().decode("utf-8", errors="replace")
+
+
+def fold(s: str) -> str:
+    """Lowercase and strip diacritics for fuzzy state-name matching."""
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    return s.lower().replace("'", "").replace(".", "").strip()
+
+
+def parse_country_block(text: str, iso2: str) -> List[Tuple[str, str, str]]:
+    """Extract (parish_name, city_name, code) tuples for one country.
+
+    Locates the marker ``// XX (ISO2) - Has postal codes``, walks until
+    the next ``// XX (ISO2)`` country marker, and pulls every
+    ``'parish' => ['code' => '<iso>', 'cities' => [ ... ]]`` block.
+    """
+    start_pat = re.compile(
+        rf"//\s+\w[^(]*\({iso2}\)\s+-\s+Has postal codes", re.M
+    )
+    m = start_pat.search(text)
+    if not m:
+        return []
+    start = m.start()
+    next_country = re.compile(r"//\s+[A-Z][A-Z &]+\s+\([A-Z]{2}(?:-[A-Z]{2})?\)", re.M)
+    after = next_country.search(text, start + 5)
+    end = after.start() if after else len(text)
+    block = text[start:end]
+
+    # Naive non-greedy capture corrupts nested ['postal_code' => '...']
+    # array literals. Instead, scan parish anchor offsets, then assign
+    # each ('city' => ['postal_code' => '...']) match to the nearest
+    # preceding parish anchor.
+    parish_anchor_re = re.compile(
+        r"'([^']+)'\s*=>\s*\[\s*'code'\s*=>\s*'[^']*'\s*,\s*'cities'\s*=>\s*\[",
+        re.S,
+    )
+    city_re = re.compile(
+        r"['\"]([^'\"]+)['\"]\s*=>\s*\[\s*'postal_code'\s*=>\s*'([^']+)'\s*\]"
+    )
+    parish_offsets: List[Tuple[int, str]] = [
+        (m.end(), m.group(1)) for m in parish_anchor_re.finditer(block)
+    ]
+    if not parish_offsets:
+        return []
+
+    out: List[Tuple[str, str, str]] = []
+    for cm in city_re.finditer(block):
+        city_pos = cm.start()
+        # Find the parish whose anchor immediately precedes city_pos.
+        parish_name = ""
+        for off, name in parish_offsets:
+            if off <= city_pos:
+                parish_name = name
+            else:
+                break
+        out.append((parish_name, cm.group(1), cm.group(2)))
+    return out
+
+
+def write_country(
+    project_root: Path,
+    iso2: str,
+    rows: List[Tuple[str, str, str]],
+    countries: List[dict],
+    states_all: List[dict],
+    dry_run: bool,
+) -> int:
+    """Resolve FKs for one country and write its contributions JSON.
+
+    Returns 0 on success, non-zero on missing country/regex failure.
+    """
+    country = next((c for c in countries if c.get("iso2") == iso2), None)
+    if country is None:
+        print(f"ERROR: {iso2} not in countries.json", file=sys.stderr)
+        return 2
+    regex_str = country.get("postal_code_regex") or ".*"
+    regex = re.compile(regex_str)
+    states = [s for s in states_all if s.get("country_id") == country["id"]]
+    state_by_name: Dict[str, dict] = {fold(s["name"]): s for s in states}
+    print(
+        f"\n=== {iso2} {country['name']} (id={country['id']}) ===\n"
+        f"states indexed: {len(states)}; regex: {regex_str}"
+    )
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    matched_state = 0
+    unknown_states: Dict[str, int] = {}
+
+    aliases = STATE_NAME_ALIASES.get(iso2, {})
+    for parish, city, code in rows:
+        if not regex.match(code):
+            skipped_bad_regex += 1
+            continue
+        canonical = aliases.get(parish, parish)
+        state = state_by_name.get(fold(canonical))
+        if state is None:
+            unknown_states[parish] = unknown_states.get(parish, 0) + 1
+        key = (code, city.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        record: Dict[str, object] = {
+            "code": code,
+            "country_id": int(country["id"]),
+            "country_code": iso2,
+        }
+        if state is not None:
+            record["state_id"] = int(state["id"])
+            record["state_code"] = state.get("iso2")
+            matched_state += 1
+        if city:
+            record["locality_name"] = city
+        record["type"] = "full"
+        record["source"] = "shipping-market-caribbean-seeder"
+        records.append(record)
+
+    print(f"Source rows:           {len(rows):,}")
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    if unknown_states:
+        print("Unknown parish/district names (not in CSC states.json):")
+        for s, n in sorted(unknown_states.items(), key=lambda x: -x[1]):
+            print(f"  {s!r}: {n}")
+
+    if dry_run:
+        return 0
+
+    target = project_root / f"contributions/postcodes/{iso2}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local PHP seeder")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    text = (
+        Path(args.input).read_text(encoding="utf-8")
+        if args.input
+        else fetch_text(SOURCE_URL)
+    )
+    print(f"Source seeder bytes: {len(text):,}")
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    states = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+
+    rc = 0
+    for iso2 in TARGETS:
+        rows = parse_country_block(text, iso2)
+        if not rows:
+            print(f"\n=== {iso2} === ERROR: no rows parsed", file=sys.stderr)
+            rc = max(rc, 2)
+            continue
+        rc = max(rc, write_country(project_root, iso2, rows, countries, states, args.dry_run))
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/BB.json
+++ b/contributions/postcodes/BB.json
@@ -1,0 +1,192 @@
+[
+  {
+    "code": "BB11000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1230,
+    "state_code": "08",
+    "locality_name": "Bridgetown",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB11114",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1230,
+    "state_code": "08",
+    "locality_name": "Belleville",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB14038",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1230,
+    "state_code": "08",
+    "locality_name": "The Garrison",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB15000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1228,
+    "state_code": "01",
+    "locality_name": "Oistins",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB15006",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1228,
+    "state_code": "01",
+    "locality_name": "Worthing",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB15138",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1228,
+    "state_code": "01",
+    "locality_name": "Rockley",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB15156",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1228,
+    "state_code": "01",
+    "locality_name": "Hastings",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB17000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1226,
+    "state_code": "03",
+    "locality_name": "Edgecliff",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB18000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1220,
+    "state_code": "10",
+    "locality_name": "Crane",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB18000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1220,
+    "state_code": "10",
+    "locality_name": "Six Cross Roads",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB19000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1225,
+    "state_code": "11",
+    "locality_name": "Welchman Hall",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB21000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1223,
+    "state_code": "06",
+    "locality_name": "Bathsheba",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB22000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1227,
+    "state_code": "05",
+    "locality_name": "s",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB23000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1229,
+    "state_code": "02",
+    "locality_name": "Belleplaine",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB24017",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1224,
+    "state_code": "04",
+    "locality_name": "Holetown",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB24024",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1224,
+    "state_code": "04",
+    "locality_name": "Sandy Lane",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB26000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1222,
+    "state_code": "09",
+    "locality_name": "Six Mens",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB26000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1224,
+    "state_code": "04",
+    "locality_name": "Speightstown",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "BB27000",
+    "country_id": 20,
+    "country_code": "BB",
+    "state_id": 1221,
+    "state_code": "07",
+    "locality_name": "Crab Hill",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  }
+]

--- a/contributions/postcodes/KY.json
+++ b/contributions/postcodes/KY.json
@@ -1,0 +1,92 @@
+[
+  {
+    "code": "KY1-1000",
+    "country_id": 41,
+    "country_code": "KY",
+    "state_id": 5251,
+    "state_code": "01",
+    "locality_name": "George Town",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "KY1-1200",
+    "country_id": 41,
+    "country_code": "KY",
+    "state_id": 5251,
+    "state_code": "01",
+    "locality_name": "Seven Mile Beach",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "KY1-1200",
+    "country_id": 41,
+    "country_code": "KY",
+    "state_id": 5251,
+    "state_code": "01",
+    "locality_name": "West Bay",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "KY1-1600",
+    "country_id": 41,
+    "country_code": "KY",
+    "state_id": 5251,
+    "state_code": "01",
+    "locality_name": "Bodden Town",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "KY1-1700",
+    "country_id": 41,
+    "country_code": "KY",
+    "state_id": 5251,
+    "state_code": "01",
+    "locality_name": "East End",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "KY1-1800",
+    "country_id": 41,
+    "country_code": "KY",
+    "state_id": 5251,
+    "state_code": "01",
+    "locality_name": "North Side",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "KY2-2000",
+    "country_id": 41,
+    "country_code": "KY",
+    "state_id": 5252,
+    "state_code": "02",
+    "locality_name": "West End",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "KY2-2001",
+    "country_id": 41,
+    "country_code": "KY",
+    "state_id": 5252,
+    "state_code": "02",
+    "locality_name": "Spot Bay",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "KY3-2500",
+    "country_id": 41,
+    "country_code": "KY",
+    "state_id": 5253,
+    "state_code": "03",
+    "locality_name": "Blossom Village",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  }
+]

--- a/contributions/postcodes/TT.json
+++ b/contributions/postcodes/TT.json
@@ -1,0 +1,262 @@
+[
+  {
+    "code": "100101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3363,
+    "state_code": "POS",
+    "locality_name": "Port of Spain",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "100103",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3363,
+    "state_code": "POS",
+    "locality_name": "St. Clair",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "100104",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3363,
+    "state_code": "POS",
+    "locality_name": "Woodbrook",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "100105",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3363,
+    "state_code": "POS",
+    "locality_name": "Newtown",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "110101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3367,
+    "state_code": "DMN",
+    "locality_name": "Diego Martin",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "110105",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3367,
+    "state_code": "DMN",
+    "locality_name": "Westmoorings",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "120101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3357,
+    "state_code": "SJL",
+    "locality_name": "San Juan",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "120201",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3357,
+    "state_code": "SJL",
+    "locality_name": "Barataria",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "130101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3358,
+    "state_code": "TUP",
+    "locality_name": "Tunapuna",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "130102",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3358,
+    "state_code": "TUP",
+    "locality_name": "Trincity",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "130201",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3358,
+    "state_code": "TUP",
+    "locality_name": "Piarco",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "300101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3362,
+    "state_code": "ARI",
+    "locality_name": "Arima",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "310101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3361,
+    "state_code": "SGE",
+    "locality_name": "Sangre Grande",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "320101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3356,
+    "state_code": "MRC",
+    "locality_name": "Mayaro",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "320201",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3356,
+    "state_code": "MRC",
+    "locality_name": "Rio Claro",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "500101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3359,
+    "state_code": "SFO",
+    "locality_name": "San Fernando",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "500104",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3359,
+    "state_code": "SFO",
+    "locality_name": "Gulf View",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "500501",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3366,
+    "state_code": "CHA",
+    "locality_name": "Chaguanas",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "520101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3354,
+    "state_code": "CTT",
+    "locality_name": "Couva",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "530101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3368,
+    "state_code": "PRT",
+    "locality_name": "Princes Town",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "540101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3365,
+    "state_code": "PED",
+    "locality_name": "Penal",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "550101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3364,
+    "state_code": "SIP",
+    "locality_name": "Siparia",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "700101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 3360,
+    "state_code": "PTF",
+    "locality_name": "Point Fortin",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "850101",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 5735,
+    "state_code": "TOB",
+    "locality_name": "Scarborough",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "850201",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 5735,
+    "state_code": "TOB",
+    "locality_name": "Crown Point",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  },
+  {
+    "code": "850301",
+    "country_id": 223,
+    "country_code": "TT",
+    "state_id": 5735,
+    "state_code": "TOB",
+    "locality_name": "Plymouth",
+    "type": "full",
+    "source": "shipping-market-caribbean-seeder"
+  }
+]


### PR DESCRIPTION
## Summary
Adds postcode coverage for three Caribbean territories that previously had no #1039 data. Bundle pattern follows the recently-merged singleton-territory PRs (#1526, #1527, #1530).

| iso2 | Country | Records | State FK |
|---|---|---:|---:|
| **KY** | Cayman Islands | 9 | 100% |
| **BB** | Barbados | 19 | 100% |
| **TT** | Trinidad & Tobago | 26 | 100% |
| | **Total** | **54** | **100%** |

## Source

- **Repo:** [`usama216/shipping-market`](https://github.com/usama216/shipping-market) — Laravel `CaribbeanLocationSeeder.php`, hand-curated parish/district + postcode data for 22 Caribbean territories.
- **Provenance:** Postal codes themselves are factual data published by the national postal services (Cayman Post, Barbados Postal Service, TTPost) and are not copyrightable.
- **Per-row attribution:** `source: "shipping-market-caribbean-seeder"`.
- **License caveat:** Upstream repo ships without a formal license. Per CSC's `feedback_postcode_pipelines.md` source-class taxonomy this is **Tier 5** (free redistribution, flagged in PR description). Because we redistribute only the codes themselves (facts), not the seeder's structure or surrounding code, reuse is acceptable.

## State FK resolution

- **KY**: 3 islands matched directly by name (Grand Cayman, Cayman Brac, Little Cayman).
- **BB**: 11 parishes matched directly by name (`Saint Michael` → 08, `Christ Church` → 01, etc.).
- **TT**: 15 administrative areas matched by name (`Port of Spain` → POS, `Tobago` → TOB, etc.). One alias for `Mayaro-Rio Claro` (seeder) → `Rio Claro-Mayaro` (CSC, MRC).

## Importer

- `bin/scripts/sync/import_caribbean_postcodes.py` — fetches the PHP seeder, walks parish anchors, scans `'city' => ['postal_code' => '...']` literals, idempotent merge by `(code, locality_name)`.

Resolves a Tier-E gap from `bin/scripts/sync/POSTCODES_1039_SOURCES_RESEARCH.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)