### PR TITLE
fix(timezones): correct 72 city rows with foreign IANA zones (#1085 follow-up)

### DIFF
--- a/.github/fixes-docs/FIX_1085_FOREIGN_TIMEZONES_SUMMARY.md
+++ b/.github/fixes-docs/FIX_1085_FOREIGN_TIMEZONES_SUMMARY.md
@@ -1,0 +1,64 @@
+# Fix Summary: Foreign-zone city timezone cleanup (#1085 follow-up)
+
+Closes the residual scope from #1085. The original issue called out a handful
+of countries (ES, RO) where city timezone fields pointed at the wrong IANA zone.
+Master is clean for those. This PR sweeps every remaining city row whose
+timezone field belongs to a neighbouring country.
+
+## Scope
+
+72 rows across 4 country files:
+
+| File | Wrong zone | Correct zone | Rows |
+|------|------------|--------------|-----:|
+| `contributions/cities/VN.json` | `Asia/Bangkok` | `Asia/Ho_Chi_Minh` | 63 |
+| `contributions/cities/PS.json` | `Asia/Jerusalem` | `Asia/Hebron` | 6 |
+| `contributions/cities/UZ.json` | `Asia/Bishkek` | `Asia/Tashkent` | 2 |
+| `contributions/cities/ID.json` | `Asia/Ho_Chi_Minh` | `Asia/Pontianak` | 1 |
+
+## Per-file rationale
+
+- **VN (63 rows):** All 63 sit in Vietnamese provinces (state codes spanning
+  northern, central, and southern VN). Vietnam observes ICT (UTC+7) in a single
+  IANA zone: `Asia/Ho_Chi_Minh`. `Asia/Bangkok` is Thailand's zone — never
+  correct for a Vietnamese city.
+
+- **PS (6 rows):** All 6 sit in West Bank governates — Bethlehem (BTH),
+  Hebron (HBN), Jerusalem governate (JEM), Salfit (SLT). The IANA mapping for
+  the Palestinian territories is geographic: `Asia/Gaza` for Gaza Strip,
+  `Asia/Hebron` for the West Bank. None of the 6 are in the Gaza Strip,
+  so all map to `Asia/Hebron`. `Asia/Jerusalem` is Israel's zone.
+
+- **UZ (2 rows):** Both are in Fergana Region (state_code `FA`), eastern
+  Uzbekistan. Uzbekistan observes UZT (UTC+5) under `Asia/Tashkent` (the
+  most populous IANA zone for the country) or `Asia/Samarkand`. `Asia/Bishkek`
+  is Kyrgyzstan's zone — never correct for a Uzbek city.
+
+- **ID (1 row):** Sambas (West Kalimantan, state_code `KB`) observes WIB
+  (UTC+7) under `Asia/Pontianak`. `Asia/Ho_Chi_Minh` is Vietnam's zone.
+
+## Out of scope
+
+- **TF (Tromelin Island):** Currently tagged `Indian/Reunion`. Tromelin is
+  administered by France as part of the Scattered Islands (TAAF) but is
+  disputed with Mauritius. The current zone reflects de-facto administration —
+  left untouched.
+- **FR (Nouméa, id 160039):** Tagged `Pacific/Noumea`. State_code is `NC`
+  (New Caledonia, an FR overseas collectivity). This is correct, not a bug —
+  excluded from the sweep.
+
+## Verification
+
+```
+$ python3 bin/scripts/fixes/foreign_timezone_fixes.py
+Total rows fixed: 72
+$ python3 bin/scripts/fixes/foreign_timezone_fixes.py
+Total rows fixed: 0   # idempotent
+```
+
+After-counts: 0 VN rows tagged `Asia/Bangkok`, 0 PS rows tagged
+`Asia/Jerusalem`, 0 UZ rows tagged `Asia/Bishkek`, 0 ID rows tagged
+`Asia/Ho_Chi_Minh`.
+
+Schema, cross-reference, coordinate-bounds, and duplicate validators all
+pass — no FK or geometry changes, only the `timezone` text field.

--- a/bin/scripts/fixes/foreign_timezone_fixes.py
+++ b/bin/scripts/fixes/foreign_timezone_fixes.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Fix 72 city rows tagged with foreign IANA timezones.
+
+Issue #1085 close-out follow-up: VN/PS/UZ/ID rows whose timezone field
+points to a neighbouring country's zone instead of the correct local zone.
+
+Idempotent. Safe to re-run.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3] / "contributions" / "cities"
+
+PLAN = [
+    {
+        "file": "VN.json",
+        "rule": "Asia/Bangkok -> Asia/Ho_Chi_Minh",
+        "match": lambda r: r.get("timezone") == "Asia/Bangkok",
+        "set_tz": "Asia/Ho_Chi_Minh",
+    },
+    {
+        "file": "PS.json",
+        "rule": "Asia/Jerusalem -> Asia/Hebron (all 6 rows are West Bank governates)",
+        "match": lambda r: r.get("timezone") == "Asia/Jerusalem",
+        "set_tz": "Asia/Hebron",
+    },
+    {
+        "file": "UZ.json",
+        "rule": "Asia/Bishkek -> Asia/Tashkent (Fergana Region rows)",
+        "match": lambda r: r.get("timezone") == "Asia/Bishkek",
+        "set_tz": "Asia/Tashkent",
+    },
+    {
+        "file": "ID.json",
+        "rule": "Asia/Ho_Chi_Minh -> Asia/Pontianak (Sambas, West Kalimantan)",
+        "match": lambda r: r.get("timezone") == "Asia/Ho_Chi_Minh",
+        "set_tz": "Asia/Pontianak",
+    },
+]
+
+
+def apply(plan):
+    path = ROOT / plan["file"]
+    if not path.exists():
+        sys.exit(f"missing: {path}")
+    rows = json.loads(path.read_text())
+    changed = 0
+    for r in rows:
+        if plan["match"](r) and r.get("timezone") != plan["set_tz"]:
+            r["timezone"] = plan["set_tz"]
+            changed += 1
+    path.write_text(json.dumps(rows, indent=2, ensure_ascii=False) + "\n")
+    return changed, len(rows)
+
+
+def main():
+    print("Foreign-timezone cleanup (issue #1085 follow-up)")
+    print("=" * 60)
+    total = 0
+    for plan in PLAN:
+        changed, n = apply(plan)
+        total += changed
+        print(f"  {plan['file']:>10}  {plan['rule']}")
+        print(f"  {'':>10}  changed {changed} of {n} rows")
+    print("=" * 60)
+    print(f"Total rows fixed: {total}")
+
+
+if __name__ == "__main__":
+    main()

--- a/contributions/cities/ID.json
+++ b/contributions/cities/ID.json
@@ -32321,7 +32321,7 @@
     "longitude": "109.35000000",
     "native": "Sambas",
     "population": 57295,
-    "timezone": "Asia/Ho_Chi_Minh",
+    "timezone": "Asia/Pontianak",
     "translations": {
       "br": "Sambas",
       "ko": "삼바스",

--- a/contributions/cities/PS.json
+++ b/contributions/cities/PS.json
@@ -13,7 +13,7 @@
     "longitude": "35.11743230",
     "native": "بتير",
     "population": 56746,
-    "timezone": "Asia/Jerusalem",
+    "timezone": "Asia/Hebron",
     "translations": {
       "br": "Battir",
       "ko": "바티르",
@@ -300,7 +300,7 @@
     "longitude": "35.15014530",
     "native": "الخضر",
     "population": 10088,
-    "timezone": "Asia/Jerusalem",
+    "timezone": "Asia/Hebron",
     "translations": {
       "br": "al-Khader",
       "ko": "알-카데르",
@@ -341,7 +341,7 @@
     "longitude": "35.09976230",
     "native": "نحالين",
     "population": 1021,
-    "timezone": "Asia/Jerusalem",
+    "timezone": "Asia/Hebron",
     "translations": {
       "br": "Nahalin",
       "ko": "나할린",
@@ -1202,7 +1202,7 @@
     "longitude": "35.12317630",
     "native": "سعير",
     "population": 3151,
-    "timezone": "Asia/Jerusalem",
+    "timezone": "Asia/Hebron",
     "translations": {
       "br": "Sa'ir",
       "ko": "사이르",
@@ -2391,7 +2391,7 @@
     "longitude": "35.24263130",
     "native": "حزما",
     "population": 8194,
-    "timezone": "Asia/Jerusalem",
+    "timezone": "Asia/Hebron",
     "translations": {
       "br": "Hizma",
       "ko": "히즈마",
@@ -4605,7 +4605,7 @@
     "longitude": "35.06050810",
     "native": "كفر الديك",
     "population": 4280,
-    "timezone": "Asia/Jerusalem",
+    "timezone": "Asia/Hebron",
     "translations": {
       "br": "Kafr ad-Dik",
       "ko": "카프르 아드딕",

--- a/contributions/cities/UZ.json
+++ b/contributions/cities/UZ.json
@@ -3908,7 +3908,7 @@
     "longitude": "71.98026000",
     "native": "Quvasoy",
     "population": 96900,
-    "timezone": "Asia/Bishkek",
+    "timezone": "Asia/Tashkent",
     "translations": {
       "br": "Quvasoy",
       "ko": "쿠바소이",
@@ -4359,7 +4359,7 @@
     "longitude": "71.80512000",
     "native": "Shohimardon",
     "population": 5100,
-    "timezone": "Asia/Bishkek",
+    "timezone": "Asia/Tashkent",
     "translations": {
       "br": "Shohimardon",
       "ko": "쇼히마르돈",

--- a/contributions/cities/VN.json
+++ b/contributions/cities/VN.json
@@ -218,7 +218,7 @@
     "longitude": "106.19460000",
     "native": "Bắc Giang",
     "population": 450000,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Bắc Giang",
       "ko": "박장",
@@ -259,7 +259,7 @@
     "longitude": "105.83481000",
     "native": "Bắc Kạn",
     "population": 45036,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Bắc Kạn",
       "ko": "박칸",
@@ -300,7 +300,7 @@
     "longitude": "106.07631000",
     "native": "Bắc Ninh",
     "population": 287658,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Bắc Ninh",
       "ko": "박닌",
@@ -464,7 +464,7 @@
     "longitude": "106.25786000",
     "native": "Cao Bằng",
     "population": 73549,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Cao Bằng",
       "ko": "까오방",
@@ -833,7 +833,7 @@
     "longitude": "107.27345000",
     "native": "Cẩm Phả",
     "population": 156000,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Deuit Phả",
       "ko": "깜 파",
@@ -997,7 +997,7 @@
     "longitude": "103.02301000",
     "native": "Dien well Phu",
     "population": 84672,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Dien Bien Phu",
       "ko": "디엔비엔푸",
@@ -1161,7 +1161,7 @@
     "longitude": "106.68345000",
     "native": "Haiphong",
     "population": 2625200,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Haiphong",
       "ko": "하이퐁",
@@ -1202,7 +1202,7 @@
     "longitude": "105.80854700",
     "native": "Ba Đình",
     "population": 168300,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Ba Đình",
       "ko": "바딘",
@@ -2104,7 +2104,7 @@
     "longitude": "106.02959000",
     "native": "Huyện Bình Lục",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Bình Lục",
       "ko": "후옌 빈 룩",
@@ -4236,7 +4236,7 @@
     "longitude": "105.46817000",
     "native": "Huyện Cẩm Thủy",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Cẩm Thủy",
       "ko": "후옌 깜 투이",
@@ -4277,7 +4277,7 @@
     "longitude": "106.00186000",
     "native": "Huyện Cẩm Xuyên",
     "population": 12857,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Cẩm Xuyên",
       "ko": "후옌 캄 쑤옌",
@@ -5548,7 +5548,7 @@
     "longitude": "106.34386000",
     "native": "Huyện Hũu Lũng",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Hũu Lũng",
       "ko": "후옌 후 룽",
@@ -5630,7 +5630,7 @@
     "longitude": "105.62523000",
     "native": "Huyện Hưng Nguyên",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Hưng Nguyên",
       "ko": "후옌 흥 응우옌",
@@ -5917,7 +5917,7 @@
     "longitude": "105.88894000",
     "native": "Huyện Hậu Lộc",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Hậu Lộc",
       "ko": "후옌 하우 록",
@@ -6163,7 +6163,7 @@
     "longitude": "105.97455000",
     "native": "Huyện Khoái Châu",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Khoái Châu",
       "ko": "후옌 코아이 차우",
@@ -8910,7 +8910,7 @@
     "longitude": "105.75442000",
     "native": "Huyện Nho Quan",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Nho Quan",
       "ko": "후옌 노 콴",
@@ -9402,7 +9402,7 @@
     "longitude": "107.71458000",
     "native": "Huyện Phú Vang",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Phú Vang",
       "ko": "후옌 푸 방",
@@ -9648,7 +9648,7 @@
     "longitude": "106.36705000",
     "native": "Huyện Quảng Trạch",
     "population": 1000,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Quảng Trạch",
       "ko": "후옌 꽝 짜흐",
@@ -9853,7 +9853,7 @@
     "longitude": "105.09173000",
     "native": "Huyện Quỳ Châu",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Quỳ Châu",
       "ko": "후옌 꾸이 쩌우",
@@ -10058,7 +10058,7 @@
     "longitude": "103.84037000",
     "native": "Huyện Sa Pa",
     "population": 10554,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Sa Pa",
       "ko": "후옌 사 파",
@@ -10919,7 +10919,7 @@
     "longitude": "105.68144000",
     "native": "Huyện Thiệu Hóa",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Thiệu Hóa",
       "ko": "후옌 티에우 호아",
@@ -11001,7 +11001,7 @@
     "longitude": "106.07515000",
     "native": "Huyện Thuận Thành",
     "population": 199577,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Thuận Thành",
       "ko": "후옌 투엔 탄",
@@ -11862,7 +11862,7 @@
     "longitude": "107.16034000",
     "native": "Huyện Triệu Phong",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Triệu Phong",
       "ko": "후옌 트리에우 퐁",
@@ -12026,7 +12026,7 @@
     "longitude": "106.32543000",
     "native": "Huyện Trà Lĩnh",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Trà Lĩnh",
       "ko": "후옌 짜 린",
@@ -12477,7 +12477,7 @@
     "longitude": "106.02678000",
     "native": "Huyện Tuyên Hóa",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Tuyên Hóa",
       "ko": "후옌 투옌 호아",
@@ -13994,7 +13994,7 @@
     "longitude": "105.57586000",
     "native": "Huyện Yên Lạc",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Yên Lạc",
       "ko": "후옌 옌 락",
@@ -14322,7 +14322,7 @@
     "longitude": "105.61482000",
     "native": "Huyện Yên Định",
     "population": 0,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huyện Yên Định",
       "ko": "후옌 옌딘",
@@ -15634,7 +15634,7 @@
     "longitude": "107.59546000",
     "native": "Huế",
     "population": 1380000,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Huế",
       "ko": "색조",
@@ -15675,7 +15675,7 @@
     "longitude": "104.98357000",
     "native": "Hà Giang",
     "population": 58408,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Ha Giang",
       "ko": "하장",
@@ -15757,7 +15757,7 @@
     "longitude": "105.90569000",
     "native": "Hà Tĩnh",
     "population": 27728,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Hà Tĩnh",
       "ko": "하띤",
@@ -15798,7 +15798,7 @@
     "longitude": "105.74947330",
     "native": "Cầu Giấy",
     "population": 46469,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Cầu Giấy",
       "ko": "Cầu Giấy",
@@ -15839,7 +15839,7 @@
     "longitude": "105.33759000",
     "native": "Hòa Bình",
     "population": 121309,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Hòa Bình",
       "ko": "호아빈",
@@ -15880,7 +15880,7 @@
     "longitude": "106.05112000",
     "native": "Hưng Yên",
     "population": 118646,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Hưng Yên",
       "ko": "흥옌",
@@ -15921,7 +15921,7 @@
     "longitude": "107.07336000",
     "native": "Hạ Long",
     "population": 270054,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Hạ Hir",
       "ko": "하롱베이",
@@ -15962,7 +15962,7 @@
     "longitude": "106.33302000",
     "native": "Hải Dương",
     "population": 241373,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Hải Dương",
       "ko": "하이즈엉",
@@ -16290,7 +16290,7 @@
     "longitude": "103.97066000",
     "native": "Lào Cai",
     "population": 130671,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Lào Cai",
       "ko": "라오까이",
@@ -16331,7 +16331,7 @@
     "longitude": "106.76101000",
     "native": "Lạng Sơn",
     "population": 200108,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Lạng Sơn",
       "ko": "랑손",
@@ -16372,7 +16372,7 @@
     "longitude": "107.96619000",
     "native": "Móng Cái",
     "population": 108553,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Móng Cái",
       "ko": "몽까이",
@@ -16454,7 +16454,7 @@
     "longitude": "106.17729000",
     "native": "Nam Định",
     "population": 448225,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Nam Định",
       "ko": "남딘",
@@ -16536,7 +16536,7 @@
     "longitude": "105.97965000",
     "native": "Ninh Bình",
     "population": 36864,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Ninh Bình",
       "ko": "닌빈",
@@ -16700,7 +16700,7 @@
     "longitude": "105.91221000",
     "native": "Phủ Lý",
     "population": 136654,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Phủ Lý",
       "ko": "풀리",
@@ -16905,7 +16905,7 @@
     "longitude": "105.71369010",
     "native": "Hà Đông",
     "population": 11500,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Hà Đông",
       "ko": "하동",
@@ -17028,7 +17028,7 @@
     "longitude": "103.84415000",
     "native": "Sa pa",
     "population": 10554,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Sa Pa",
       "ko": "사파",
@@ -17151,7 +17151,7 @@
     "longitude": "103.91882000",
     "native": "Sơn La",
     "population": 106052,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Sơn La",
       "ko": "손라",
@@ -17192,7 +17192,7 @@
     "longitude": "105.84126630",
     "native": "Hai Bà Trưng",
     "population": 8053663,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Hai Bà Trưng",
       "ko": "하이 바 쯩",
@@ -17274,7 +17274,7 @@
     "longitude": "105.76667000",
     "native": "Thanh Hóa",
     "population": 850000,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Thanh Hóa",
       "ko": "탄호아",
@@ -17602,7 +17602,7 @@
     "longitude": "106.34002000",
     "native": "Thái Bình",
     "population": 53071,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Thái Bình",
       "ko": "타이빈",
@@ -17643,7 +17643,7 @@
     "longitude": "105.84817000",
     "native": "Thái Nguyên",
     "population": 340403,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Thai Nguyên",
       "ko": "타이 응우옌",
@@ -17725,7 +17725,7 @@
     "longitude": "105.83867000",
     "native": "Thị Xã Bắc Kạn",
     "population": 45036,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Trugarez Xã Bắc Kạn",
       "ko": "티 싸 박 칸",
@@ -18176,7 +18176,7 @@
     "longitude": "105.21424000",
     "native": "Tuyên Quang",
     "population": 104645,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Tuyên Quang",
       "ko": "투옌 꽝",
@@ -18299,7 +18299,7 @@
     "longitude": "105.69232000",
     "native": "VINH",
     "population": 790000,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Vinh",
       "ko": "빈",
@@ -18340,7 +18340,7 @@
     "longitude": "105.40198000",
     "native": "Việt Trì",
     "population": 415280,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Việt Trì",
       "ko": "비엣 트리",
@@ -18422,7 +18422,7 @@
     "longitude": "105.60489000",
     "native": "Vĩnh Yên",
     "population": 119128,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Vĩnh Yên",
       "ko": "빈옌",
@@ -18545,7 +18545,7 @@
     "longitude": "104.91130000",
     "native": "Yên Bái",
     "population": 100631,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Yên Bái",
       "ko": "옌바이",
@@ -18586,7 +18586,7 @@
     "longitude": "105.66667000",
     "native": "Yên Vinh",
     "population": 107082,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Yên Vinh",
       "ko": "옌빈",
@@ -18668,7 +18668,7 @@
     "longitude": "107.10031000",
     "native": "Ðông Hà",
     "population": 164228,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Ðông Hà",
       "ko": "동하",
@@ -19037,7 +19037,7 @@
     "longitude": "105.83358610",
     "native": "Hoàn Kiếm",
     "population": 23942,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Hoàn Kiếm",
       "ko": "호안끼엠",
@@ -19078,7 +19078,7 @@
     "longitude": "105.81704700",
     "native": "Hoàng Mai",
     "population": 76238,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Hoàng Mai",
       "ko": "호앙마이",
@@ -19119,7 +19119,7 @@
     "longitude": "105.84909840",
     "native": "Long Biên",
     "population": 135618,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Biên hir",
       "ko": "롱비엔",
@@ -19201,7 +19201,7 @@
     "longitude": "105.77920430",
     "native": "Tây Hồ",
     "population": 13676,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Tây Hồ",
       "ko": "타이 호",
@@ -19242,7 +19242,7 @@
     "longitude": "105.79696040",
     "native": "Thanh Xuân",
     "population": 293292,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Thanh Xuân",
       "ko": "탄쑤언",
@@ -19488,7 +19488,7 @@
     "longitude": "105.78534730",
     "native": "Gia Lâm",
     "population": 40527,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Gia Lâm",
       "ko": "지아 램",
@@ -19898,7 +19898,7 @@
     "longitude": "105.76821790",
     "native": "Thanh Trì",
     "population": 59980,
-    "timezone": "Asia/Bangkok",
+    "timezone": "Asia/Ho_Chi_Minh",
     "translations": {
       "br": "Thanh Trì",
       "ko": "탄찌",


### PR DESCRIPTION
Closes the residual scope from #1085. The original issue called out a handful of countries (ES, RO) where city timezone fields pointed at the wrong IANA zone. Master is clean for those — this PR sweeps every remaining city row whose timezone points at a neighbouring country's zone.

**Source:** [IANA Time Zone Database (tzdata)](https://www.iana.org/time-zones) — canonical zone-to-territory mapping. Cross-checked against [Wikipedia: List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).

## Scope (72 rows across 4 files)

| File | Wrong zone | Correct zone | Rows |
|------|------------|--------------|-----:|
| `cities/VN.json` | `Asia/Bangkok` | `Asia/Ho_Chi_Minh` | 63 |
| `cities/PS.json` | `Asia/Jerusalem` | `Asia/Hebron` | 6 |
| `cities/UZ.json` | `Asia/Bishkek` | `Asia/Tashkent` | 2 |
| `cities/ID.json` | `Asia/Ho_Chi_Minh` | `Asia/Pontianak` | 1 |

Per-row reasoning in `.github/fixes-docs/FIX_1085_FOREIGN_TIMEZONES_SUMMARY.md`. All 6 PS rows are West Bank governates (BTH/HBN/JEM/SLT) — Gaza Strip would map to `Asia/Gaza`, none qualified. Both UZ rows are in Fergana Region (eastern UZ).

## Out of scope

- TF/Tromelin (`Indian/Reunion`) — disputed admin, left untouched.
- FR id 160039 Nouméa (`Pacific/Noumea`) — correct for state_code NC overseas.

## Verification

```
$ python3 bin/scripts/fixes/foreign_timezone_fixes.py
Total rows fixed: 72
$ python3 bin/scripts/fixes/foreign_timezone_fixes.py
Total rows fixed: 0   # idempotent
```

After-counts: 0 rows still tagged with the wrong zone in any of the 4 files. Only the `timezone` text field changes — no FK or coordinate changes.

Closes #1085 follow-up.