### PR TITLE
feat(postcodes/NA): 149 NamPost postcodes — all 14 regions (#1039)

### DIFF
--- a/bin/scripts/sync/import_namibia_postcodes.py
+++ b/bin/scripts/sync/import_namibia_postcodes.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Namibia -> contributions/postcodes/NA.json importer for issue #1039.
+
+Source data
+-----------
+The community ``KuberKode/namibia-postal-codes`` repository ships
+NamPost (Namibia Post Limited) postal codes scraped from the
+official PDF directory and reorganised into nested JSON:
+
+    {
+      "Country": { "Alpha-2": "NA", "Regions": [
+        { "RegionName": "Erongo", "RegionCode": "NA-ER",
+          "Locations": [
+            { "Location": "Swakopmund", "Postal Code": 13001 }, ...
+          ]
+        }, ...
+      ]}
+    }
+
+14 regions × ~10-35 locations each = ~155 codes, 5-digit numeric.
+
+Source URL: https://raw.githubusercontent.com/KuberKode/namibia-postal-codes/main/namibia-postal-codes.json
+
+What this script does
+---------------------
+1. Fetches the JSON via urllib.
+2. Walks ``Country.Regions[].Locations[]``.
+3. Maps source ``RegionCode`` ("NA-XX") to CSC iso2 by stripping
+   the ``NA-`` prefix — all 14 region codes match CSC's states.json
+   directly (ER, HA, KA, KE, KW, KH, KU, OW, OH, OS, ON, OT, OD, CA).
+4. Writes contributions/postcodes/NA.json idempotently.
+
+Coverage
+--------
+~155 records covering all 14 Namibian regions. Khomas (Windhoek
+metro) is the densest at ~35 codes; sparser rural regions like
+Kavango West average 2-6.
+
+License & attribution
+---------------------
+- Source: KuberKode/namibia-postal-codes (Unlicense / public domain)
+- Original data: NamPost public postal-code directory
+- Each row: ``source: "nampost-via-kuberkode"``
+
+Usage
+-----
+    python3 bin/scripts/sync/import_namibia_postcodes.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List
+
+
+SOURCE_URL = (
+    "https://raw.githubusercontent.com/KuberKode/namibia-postal-codes/"
+    "main/namibia-postal-codes.json"
+)
+
+
+def fetch_json(url: str) -> dict:
+    """Fetch and parse JSON via urllib."""
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "csc-database-postcode-importer"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=None, help="local JSON (skip fetch)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    payload = (
+        json.loads(Path(args.input).read_text(encoding="utf-8"))
+        if args.input
+        else fetch_json(SOURCE_URL)
+    )
+    regions = payload.get("Country", {}).get("Regions", [])
+    print(f"Source regions: {len(regions)}")
+
+    project_root = Path(__file__).resolve().parents[3]
+    countries = json.load(
+        (project_root / "contributions/countries/countries.json").open(encoding="utf-8")
+    )
+    na_country = next((c for c in countries if c.get("iso2") == "NA"), None)
+    if na_country is None:
+        print("ERROR: NA not in countries.json", file=sys.stderr)
+        return 2
+    regex = re.compile(na_country.get("postal_code_regex") or ".*")
+
+    states_all = json.load(
+        (project_root / "contributions/states/states.json").open(encoding="utf-8")
+    )
+    na_states = [s for s in states_all if s.get("country_id") == na_country["id"]]
+    state_by_iso2: Dict[str, dict] = {
+        s["iso2"]: s for s in na_states if s.get("iso2")
+    }
+    print(
+        f"Country: Namibia (id={na_country['id']}); "
+        f"states indexed: {len(na_states)}"
+    )
+
+    seen: set = set()
+    records: List[dict] = []
+    skipped_bad_regex = 0
+    matched_state = 0
+    unknown_regions: Dict[str, int] = {}
+
+    for region in regions:
+        region_code = (region.get("RegionCode") or "").strip()
+        # RegionCode is ISO 3166-2 ("NA-ER"); strip prefix.
+        iso2 = region_code.split("-", 1)[-1] if region_code else ""
+        state = state_by_iso2.get(iso2)
+        if state is None:
+            unknown_regions[region_code] = (
+                unknown_regions.get(region_code, 0) + len(region.get("Locations", []))
+            )
+
+        for loc in region.get("Locations", []):
+            raw_code = loc.get("Postal Code")
+            if raw_code is None:
+                continue
+            # Codes ship as integers — re-pad to 5 digits.
+            code = str(raw_code).zfill(5)
+            if not regex.match(code):
+                skipped_bad_regex += 1
+                continue
+
+            locality = (loc.get("Location") or "").strip()
+            key = (code, locality.lower())
+            if key in seen:
+                continue
+            seen.add(key)
+
+            record: Dict[str, object] = {
+                "code": code,
+                "country_id": int(na_country["id"]),
+                "country_code": "NA",
+            }
+            if state is not None:
+                record["state_id"] = int(state["id"])
+                record["state_code"] = state.get("iso2")
+                matched_state += 1
+            if locality:
+                record["locality_name"] = locality
+            record["type"] = "full"
+            record["source"] = "nampost-via-kuberkode"
+            records.append(record)
+
+    print(f"Skipped (regex fail):  {skipped_bad_regex:,}")
+    print(f"Records emitted:       {len(records):,}")
+    pct = matched_state * 100 // max(1, len(records))
+    print(f"  with state:          {matched_state:,} ({pct}%)")
+    if unknown_regions:
+        print("Unknown RegionCodes (not in CSC states.json):")
+        for r, n in sorted(unknown_regions.items(), key=lambda x: -x[1]):
+            print(f"  {r!r}: {n}")
+
+    if args.dry_run:
+        return 0
+
+    target = project_root / "contributions/postcodes/NA.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        with target.open(encoding="utf-8") as f:
+            existing = json.load(f)
+        existing_seen = {
+            (r["code"], (r.get("locality_name") or "").lower()) for r in existing
+        }
+        merged = list(existing)
+        for r in records:
+            key = (r["code"], (r.get("locality_name") or "").lower())
+            if key not in existing_seen:
+                merged.append(r)
+                existing_seen.add(key)
+        merged.sort(key=lambda r: (r["code"], r.get("locality_name", "")))
+    else:
+        merged = sorted(records, key=lambda r: (r["code"], r.get("locality_name", "")))
+
+    with target.open("w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    size_kb = target.stat().st_size / 1024
+    print(
+        f"\n[OK] Wrote {target.relative_to(project_root)} "
+        f"({len(merged):,} rows, {size_kb:.0f} KB)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contributions/postcodes/NA.json
+++ b/contributions/postcodes/NA.json
@@ -1,0 +1,1492 @@
+[
+  {
+    "code": "10000",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Windhoek Office of Exchange",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Parcel Depot",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Omeya Kiosk",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "GAME Kiosk",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Hybrid Mail",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Windhoek",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10006",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Wika Service Station Kiosk",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10007",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Bachbrecht",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10008",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Dordabis",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10009",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Eros",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10010",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Government Office Park Kiosk",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10011",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Khomasdal",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10012",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Klein Windhoek",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10013",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Wernhill Pick n Pay",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10014",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Rocky Crest",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10015",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Windhoek Central Prison",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10016",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Hosea Kutako Airport",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10017",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Ausspannplatz",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10018",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Auas Valley",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10019",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Kleine Kuppe",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10020",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Maerua Mall",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10021",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Olympia",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10022",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Pelican Square",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10023",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Pionierspark",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10024",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Pionierspark Motors Kiosk",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10025",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Prosperita",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10026",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "University of Namibia",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10027",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Craft Center",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10028",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Katutura",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10029",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "China Town",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10030",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Goreangab",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10031",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Okuryangava",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10032",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Otjomuise",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10033",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Soweto",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "10034",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 44,
+    "state_code": "KH",
+    "locality_name": "Wanaheda",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "11001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 41,
+    "state_code": "OH",
+    "locality_name": "Gobabis",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "11002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 41,
+    "state_code": "OH",
+    "locality_name": "Aminius",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "11003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 41,
+    "state_code": "OH",
+    "locality_name": "Epukiro",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "11004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 41,
+    "state_code": "OH",
+    "locality_name": "Leonardville",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "11005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 41,
+    "state_code": "OH",
+    "locality_name": "Tallismanus",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "11006",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 41,
+    "state_code": "OH",
+    "locality_name": "Witvlei",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "11007",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 41,
+    "state_code": "OH",
+    "locality_name": "Omitara",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "11008",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 41,
+    "state_code": "OH",
+    "locality_name": "Otjinene",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Otjiwarongo",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Hochfeld",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Okahandja West",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Okahandja",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Okakarara",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12006",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Okamatapati",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12007",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Okondjatu",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12008",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Osire",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12009",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Kalkfeld",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12010",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Grootfontein",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12011",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Tsumkwe",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12012",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Kombat",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "12013",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 46,
+    "state_code": "OD",
+    "locality_name": "Otavi",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Swakopmund",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Woermann & Brock Centre Kiosk",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Vineta",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Mondesa",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Henties Bay",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13006",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Arandis",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13007",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Usakos",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13008",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Karibib",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13009",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Omaruru",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13010",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Uis",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13011",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Omatjete",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13012",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Okombahe",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13013",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Walvis Bay",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13014",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Narraville",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "13015",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 43,
+    "state_code": "ER",
+    "locality_name": "Kuisebmund",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "14001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 42,
+    "state_code": "OT",
+    "locality_name": "Omuthiya",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "14002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 42,
+    "state_code": "OT",
+    "locality_name": "Tsumeb",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "14003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 42,
+    "state_code": "OT",
+    "locality_name": "Oshivelo",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "14004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 42,
+    "state_code": "OT",
+    "locality_name": "Onandjokwe",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "14005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 42,
+    "state_code": "OT",
+    "locality_name": "Oshigambo",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "14006",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 42,
+    "state_code": "OT",
+    "locality_name": "Onayena",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "14007",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 42,
+    "state_code": "OT",
+    "locality_name": "Okankolo",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "14008",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 42,
+    "state_code": "OT",
+    "locality_name": "Onankali",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "14009",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 42,
+    "state_code": "OT",
+    "locality_name": "Omuntele",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "14010",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 42,
+    "state_code": "OT",
+    "locality_name": "Onyaanya",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "14011",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 42,
+    "state_code": "OT",
+    "locality_name": "Okaukuejo",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "15001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 37,
+    "state_code": "ON",
+    "locality_name": "Oshakati",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "15002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 37,
+    "state_code": "ON",
+    "locality_name": "Ondangwa",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "15003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 37,
+    "state_code": "ON",
+    "locality_name": "Oluno",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "15004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 37,
+    "state_code": "ON",
+    "locality_name": "Oshakati Pick n Pay",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "15005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 37,
+    "state_code": "ON",
+    "locality_name": "Oshakati Spar",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "15006",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 37,
+    "state_code": "ON",
+    "locality_name": "Ongwediva",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "16001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 39,
+    "state_code": "OS",
+    "locality_name": "Outapi",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "16002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 39,
+    "state_code": "OS",
+    "locality_name": "Onandjaba",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "16003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 39,
+    "state_code": "OS",
+    "locality_name": "Oshikuku",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "16004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 39,
+    "state_code": "OS",
+    "locality_name": "Onesi",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "16005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 39,
+    "state_code": "OS",
+    "locality_name": "Onawa",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "16006",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 39,
+    "state_code": "OS",
+    "locality_name": "Ruacana",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "16007",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 39,
+    "state_code": "OS",
+    "locality_name": "Onaanda",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "16008",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 39,
+    "state_code": "OS",
+    "locality_name": "Okahao",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "16009",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 39,
+    "state_code": "OS",
+    "locality_name": "Tsandi",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "16010",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 39,
+    "state_code": "OS",
+    "locality_name": "Ogongo",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "17001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 40,
+    "state_code": "OW",
+    "locality_name": "Eenhana",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "17002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 40,
+    "state_code": "OW",
+    "locality_name": "Ondobe",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "17003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 40,
+    "state_code": "OW",
+    "locality_name": "Okongo",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "17004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 40,
+    "state_code": "OW",
+    "locality_name": "Ongha",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "17005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 40,
+    "state_code": "OW",
+    "locality_name": "Ohangwena",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "17006",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 40,
+    "state_code": "OW",
+    "locality_name": "Omungwelume",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "17007",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 40,
+    "state_code": "OW",
+    "locality_name": "Ongenga",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "17008",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 40,
+    "state_code": "OW",
+    "locality_name": "Oshikango",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "17009",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 40,
+    "state_code": "OW",
+    "locality_name": "Oshikango Savings Bank",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "17010",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 40,
+    "state_code": "OW",
+    "locality_name": "Endola",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "18001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 35,
+    "state_code": "KW",
+    "locality_name": "Nkurenkuru",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "18002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 35,
+    "state_code": "KW",
+    "locality_name": "Mpungu",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "19001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 36,
+    "state_code": "KE",
+    "locality_name": "Rundu",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "19002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 36,
+    "state_code": "KE",
+    "locality_name": "Divundu",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "20001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 47,
+    "state_code": "CA",
+    "locality_name": "Ngweze",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "20002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 47,
+    "state_code": "CA",
+    "locality_name": "Katima Mulilo Kiosk",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "20003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 47,
+    "state_code": "CA",
+    "locality_name": "Mayuni",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "20004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 47,
+    "state_code": "CA",
+    "locality_name": "Bukalo",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "20005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 47,
+    "state_code": "CA",
+    "locality_name": "Chincimane",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "21001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 34,
+    "state_code": "KU",
+    "locality_name": "Opuwo",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "21002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 34,
+    "state_code": "KU",
+    "locality_name": "Khorixas",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "21003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 34,
+    "state_code": "KU",
+    "locality_name": "Fransfontein",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "21004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 34,
+    "state_code": "KU",
+    "locality_name": "Kamanjab",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "21005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 34,
+    "state_code": "KU",
+    "locality_name": "Outjo",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "21006",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 34,
+    "state_code": "KU",
+    "locality_name": "Sesfontein",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "22001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 38,
+    "state_code": "HA",
+    "locality_name": "Mariental",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "22002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 38,
+    "state_code": "HA",
+    "locality_name": "Kalkrand",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "22003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 38,
+    "state_code": "HA",
+    "locality_name": "Stampriet",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "22004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 38,
+    "state_code": "HA",
+    "locality_name": "Aranos",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "22005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 38,
+    "state_code": "HA",
+    "locality_name": "Gochas",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "22006",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 38,
+    "state_code": "HA",
+    "locality_name": "Gibeon",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "22007",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 38,
+    "state_code": "HA",
+    "locality_name": "Maltahöhe",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "22008",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 38,
+    "state_code": "HA",
+    "locality_name": "Rehoboth",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "22009",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 38,
+    "state_code": "HA",
+    "locality_name": "Klein Aub",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23001",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Keetmanshoop",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23002",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Tses",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23003",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Berseba",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23004",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Koës",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23005",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Aroab",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23006",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Bethanie",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23007",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Helmeringhausen",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23008",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Karasburg",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23009",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Grünau",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23010",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Ariamsvlei",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23011",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Warmbad",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23012",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Noordoewer",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23013",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Aussenkehr",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23014",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Rosh Pinah",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23015",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Oranjemund",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23016",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Lüderitz",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  },
+  {
+    "code": "23017",
+    "country_id": 152,
+    "country_code": "NA",
+    "state_id": 45,
+    "state_code": "KA",
+    "locality_name": "Aus",
+    "type": "full",
+    "source": "nampost-via-kuberkode"
+  }
+]


### PR DESCRIPTION
## Summary
Adds NA postcode coverage — **149 NamPost codes** spanning all 14 Namibian regions. Resolves a Tier-E gap from `bin/scripts/sync/POSTCODES_1039_SOURCES_RESEARCH.md`.

| Records | State FK match | Regex fail |
|---:|---:|---:|
| 149 | 149 (100%) | 0 |

## Source

- **Repo:** [`KuberKode/namibia-postal-codes`](https://github.com/KuberKode/namibia-postal-codes) — JSON mirror of NamPost (Namibia Post Limited) public postal-code directory.
- **License:** `Unlicense` (public-domain dedication, no attribution required).
- **Per-row attribution:** `source: "nampost-via-kuberkode"`.

## State FK resolution

Source `RegionCode` is ISO 3166-2 (`NA-ER`, `NA-HA`, etc.). Strip the `NA-` prefix and the remaining 2-letter code matches CSC's `states.json` directly for **all 14** regions — no aliasing needed.

## Importer

- `bin/scripts/sync/import_namibia_postcodes.py` — fetches the JSON, walks `Country.Regions[].Locations[]`, idempotent merge by `(code, locality_name)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)