### PR TITLE
fix(countries): normalise postal_code_format alternative-separator (BM, TW)

### DIFF
--- a/contributions/countries/countries.json
+++ b/contributions/countries/countries.json
@@ -1732,7 +1732,7 @@
     "subregion_id": 6,
     "nationality": "Bermudian, Bermudan",
     "area_sq_km": 53.0,
-    "postal_code_format": "@@ ## or @@ @@",
+    "postal_code_format": "@@ ##|@@ @@",
     "postal_code_regex": "^([A-Z]{2}\\s?[A-Z0-9]{2})$",
     "timezones": [
       {
@@ -14384,7 +14384,7 @@
     "subregion_id": 12,
     "nationality": "Chinese, Taiwanese",
     "area_sq_km": 35980.0,
-    "postal_code_format": "###/#####/######",
+    "postal_code_format": "###|#####|######",
     "postal_code_regex": "^(\\d{3}(?:\\d{2,3})?)$",
     "timezones": [
       {


### PR DESCRIPTION
The convention used by 11 multi-format countries (GB/GG/IM/JE/BH/IR/LB/NL/PY/SH and AU-territory mirrors) is to separate alternative postal code formats with the pipe character `|`. Two outliers used non-standard separators:

| Country | Before | After |
|---------|--------|-------|
| BM | `@@ ## or @@ @@` | `@@ ##\|@@ @@` |
| TW | `###/#####/######` | `###\|#####\|######` |

Pure-cosmetic. `postal_code_regex` is unchanged for both, and no postcode rows are touched — only the human-readable format hint normalises to the existing convention.

Why it matters: downstream postal-format parsers (e.g. csc-validator, the export tool's postcode preview) iterate `format.split('|')` to render alternatives. The non-pipe forms produce garbled previews.