### PR TITLE
fix(JP): update Japan Post KEN_ALL download URL (closes #1543)

### DIFF
--- a/bin/scripts/sync/import_japan_post_postcodes.py
+++ b/bin/scripts/sync/import_japan_post_postcodes.py
@@ -5,7 +5,7 @@ Source data
 -----------
 Japan Post publishes the canonical 7-digit postcode-to-locality mapping at:
 
-  https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip
+  https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip
 
 The file (KEN_ALL.CSV) is **Shift-JIS encoded**, ~12 MB raw, ~125,000 rows
 covering all 47 prefectures. Each row has 15 columns; the relevant ones are:
@@ -43,7 +43,7 @@ What this script does
 Usage
 -----
     python3 -c "import urllib.request; urllib.request.urlretrieve(
-      'https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip',
+      'https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip',
       '/tmp/ken_all.zip')"
     unzip -o /tmp/ken_all.zip -d /tmp/
 


### PR DESCRIPTION
## Summary

- Japan Post moved the `ken_all.zip` download endpoint. The old URL `https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip` now returns **404**.
- Replace it with the current path `https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip` in both locations inside `bin/scripts/sync/import_japan_post_postcodes.py` (header docstring + usage example).
- No data files touched — this only restores reproducibility of the JP postcode importer.

Closes #1543.

## Source

- New URL: https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip (verified `HTTP/2 200`)
- Old URL: https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip (verified `HTTP/1.1 404`)

## Test plan

- [x] `curl -sI` on the new URL returns 200 (after following redirects)
- [x] `curl -sI` on the old URL returns 404
- [ ] Re-run `python3 -c "import urllib.request; urllib.request.urlretrieve('https://www.post.japanpost.jp/service/search/zipcode/download/kogaki/zip/ken_all.zip', '/tmp/ken_all.zip')"` and confirm the zip downloads
- [ ] Run `python3 bin/scripts/sync/import_japan_post_postcodes.py --input /tmp/KEN_ALL.CSV` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)