### PR TITLE
fix(UY): normalise Spanish prepositions/articles in city names (651 rows)

### DIFF
--- a/bin/scripts/fixes/normalize_uy_prepositions.py
+++ b/bin/scripts/fixes/normalize_uy_prepositions.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Normalise Spanish prepositions/articles in Uruguay city names.
+
+Spanish toponymy lowercases interior prepositions and articles
+(``de``, ``del``, ``la``, ``las``, ``los``, ``el``, ``y``) — e.g.
+``Paso De Los Toros`` -> ``Paso de los Toros``. Many UY city ``name``
+values were imported title-cased, capitalising every token.
+
+Rules
+-----
+* Only the listed connectors are touched; every other token is left as-is.
+* A connector is lowercased only when it is *interior* — not the first
+  token of the name, and not the first token of a segment that follows a
+  separator (``-``/``/``). This keeps names like ``San Rafael - El Placer``
+  and ``Pinares - Las Delicias`` correct.
+* ``A`` is deliberately excluded: it collides with middle initials
+  (``Capitan J A Artigas``). The single genuine-preposition case
+  (``Palo A Pique``) is handled explicitly below.
+* Idempotent — safe to re-run.
+
+Usage
+-----
+    python3 bin/scripts/fixes/normalize_uy_prepositions.py --dry-run
+    python3 bin/scripts/fixes/normalize_uy_prepositions.py
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+FILE = Path("contributions/cities/UY.json")
+
+CONNECTORS = {"De", "Del", "La", "Las", "Los", "El", "Y"}
+SEPARATORS = {"-", "/", "–"}
+
+# Explicit one-offs that the generic rule cannot resolve safely.
+EXPLICIT = {
+    "Palo A Pique": "Palo a Pique",  # "a" is the preposition, not an initial
+}
+
+
+def normalize(name: str) -> str:
+    """Lowercase interior Spanish connectors in a place name."""
+    if name in EXPLICIT:
+        return EXPLICIT[name]
+
+    tokens = name.split(" ")
+    segment_start = True  # first token of the name or of a post-separator segment
+    out = []
+    for tok in tokens:
+        if tok in SEPARATORS:
+            out.append(tok)
+            segment_start = True
+            continue
+        if not segment_start and tok in CONNECTORS:
+            out.append(tok.lower())
+        else:
+            out.append(tok)
+        segment_start = False
+    return " ".join(out)
+
+
+def main() -> int:
+    """Apply (or preview) the normalisation across UY.json."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="preview without writing")
+    args = parser.parse_args()
+
+    if not FILE.exists():
+        print(f"ERROR: {FILE} not found (run from repo root)", file=sys.stderr)
+        return 1
+
+    records = json.loads(FILE.read_text(encoding="utf-8"))
+    changes = []
+    for r in records:
+        old = r.get("name", "")
+        new = normalize(old)
+        if new != old:
+            changes.append((old, new))
+            r["name"] = new
+
+    print(f"{FILE}: {len(records)} rows, {len(changes)} name(s) normalised")
+    for old, new in changes:
+        print(f"  {old!r}  ->  {new!r}")
+
+    if args.dry_run:
+        print("\n(dry run — no changes written)")
+        return 0
+
+    FILE.write_text(json.dumps(records, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"\nWrote {FILE}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contributions/cities/UY.json
+++ b/contributions/cities/UY.json
@@ -7668,7 +7668,7 @@
   },
   {
     "id": 162139,
-    "name": "Termas Del Dayman",
+    "name": "Termas del Dayman",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -7710,7 +7710,7 @@
   },
   {
     "id": 162141,
-    "name": "18 De Julio - Pueblo Nuevo",
+    "name": "18 de Julio - Pueblo Nuevo",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -7731,7 +7731,7 @@
   },
   {
     "id": 162142,
-    "name": "18 De Julio",
+    "name": "18 de Julio",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -7794,7 +7794,7 @@
   },
   {
     "id": 162145,
-    "name": "Canteras De Marelli",
+    "name": "Canteras de Marelli",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -7815,7 +7815,7 @@
   },
   {
     "id": 162146,
-    "name": "Cerros De La Calera",
+    "name": "Cerros de la Calera",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -7836,7 +7836,7 @@
   },
   {
     "id": 162147,
-    "name": "Ciudad De La Costa",
+    "name": "Ciudad de la Costa",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -7899,7 +7899,7 @@
   },
   {
     "id": 162150,
-    "name": "Rincon De Pacheco",
+    "name": "Rincon de Pacheco",
     "state_id": 3205,
     "state_code": "AR",
     "country_id": 235,
@@ -8025,7 +8025,7 @@
   },
   {
     "id": 162156,
-    "name": "Haras Del Lago",
+    "name": "Haras del Lago",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -8151,7 +8151,7 @@
   },
   {
     "id": 162162,
-    "name": "Lago Jardin Del Bosque",
+    "name": "Lago Jardin del Bosque",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -8256,7 +8256,7 @@
   },
   {
     "id": 162167,
-    "name": "Paso De Las Toscas",
+    "name": "Paso de las Toscas",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -8319,7 +8319,7 @@
   },
   {
     "id": 162170,
-    "name": "Barrancas De La Coronilla",
+    "name": "Barrancas de la Coronilla",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -8382,7 +8382,7 @@
   },
   {
     "id": 162173,
-    "name": "Rincon De Cañada Nieto",
+    "name": "Rincon de Cañada Nieto",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -8466,7 +8466,7 @@
   },
   {
     "id": 162177,
-    "name": "Fortin De Santa Rosa",
+    "name": "Fortin de Santa Rosa",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -8571,7 +8571,7 @@
   },
   {
     "id": 162182,
-    "name": "Javier De Viana",
+    "name": "Javier de Viana",
     "state_id": 3205,
     "state_code": "AR",
     "country_id": 235,
@@ -8676,7 +8676,7 @@
   },
   {
     "id": 162187,
-    "name": "Lomas De Solymar",
+    "name": "Lomas de Solymar",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -8697,7 +8697,7 @@
   },
   {
     "id": 162188,
-    "name": "Boca Del Rosario",
+    "name": "Boca del Rosario",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -8718,7 +8718,7 @@
   },
   {
     "id": 162189,
-    "name": "Cumbres De Carrasco",
+    "name": "Cumbres de Carrasco",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -8886,7 +8886,7 @@
   },
   {
     "id": 162197,
-    "name": "Estacion La Floresta",
+    "name": "Estacion la Floresta",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -9222,7 +9222,7 @@
   },
   {
     "id": 162213,
-    "name": "Cuchilla De Buricayupi",
+    "name": "Cuchilla de Buricayupi",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -9747,7 +9747,7 @@
   },
   {
     "id": 162238,
-    "name": "Pueblo De Alvarez",
+    "name": "Pueblo de Alvarez",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -9789,7 +9789,7 @@
   },
   {
     "id": 162240,
-    "name": "Puntas De Maciel",
+    "name": "Puntas de Maciel",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -9810,7 +9810,7 @@
   },
   {
     "id": 162241,
-    "name": "Estacion Capilla Del Sauce",
+    "name": "Estacion Capilla del Sauce",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -9852,7 +9852,7 @@
   },
   {
     "id": 162243,
-    "name": "Cuchilla De Fuego",
+    "name": "Cuchilla de Fuego",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -9999,7 +9999,7 @@
   },
   {
     "id": 162250,
-    "name": "Sauce De Portezuelo",
+    "name": "Sauce de Portezuelo",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -10041,7 +10041,7 @@
   },
   {
     "id": 162252,
-    "name": "Arenas De Jose Ignacio",
+    "name": "Arenas de Jose Ignacio",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -10083,7 +10083,7 @@
   },
   {
     "id": 162254,
-    "name": "Termas De Almiron",
+    "name": "Termas de Almiron",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -10125,7 +10125,7 @@
   },
   {
     "id": 162256,
-    "name": "Rincon De Valentin",
+    "name": "Rincon de Valentin",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -10146,7 +10146,7 @@
   },
   {
     "id": 162257,
-    "name": "Chacras De Paysandu",
+    "name": "Chacras de Paysandu",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -10167,7 +10167,7 @@
   },
   {
     "id": 162258,
-    "name": "Barra De Valizas",
+    "name": "Barra de Valizas",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -10209,7 +10209,7 @@
   },
   {
     "id": 162260,
-    "name": "Cuchilla De Guaviyu",
+    "name": "Cuchilla de Guaviyu",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -10293,7 +10293,7 @@
   },
   {
     "id": 162264,
-    "name": "Sarandi De Arapey",
+    "name": "Sarandi de Arapey",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -10335,7 +10335,7 @@
   },
   {
     "id": 162266,
-    "name": "Rincon Del Pino",
+    "name": "Rincon del Pino",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -10377,7 +10377,7 @@
   },
   {
     "id": 162268,
-    "name": "Rincon Del Bonete",
+    "name": "Rincon del Bonete",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -10482,7 +10482,7 @@
   },
   {
     "id": 162273,
-    "name": "Pueblo De Arriba",
+    "name": "Pueblo de Arriba",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -10503,7 +10503,7 @@
   },
   {
     "id": 162274,
-    "name": "Pueblo Del Barro",
+    "name": "Pueblo del Barro",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -10524,7 +10524,7 @@
   },
   {
     "id": 162275,
-    "name": "Sauce De Batovi",
+    "name": "Sauce de Batovi",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -10545,7 +10545,7 @@
   },
   {
     "id": 162276,
-    "name": "Rincon De Pereira",
+    "name": "Rincon de Pereira",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -10566,7 +10566,7 @@
   },
   {
     "id": 162277,
-    "name": "Punta De Carretera",
+    "name": "Punta de Carretera",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -10587,7 +10587,7 @@
   },
   {
     "id": 162278,
-    "name": "Puntas Del Parao",
+    "name": "Puntas del Parao",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -10608,7 +10608,7 @@
   },
   {
     "id": 162279,
-    "name": "Arrocera El Tigre",
+    "name": "Arrocera el Tigre",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -10629,7 +10629,7 @@
   },
   {
     "id": 162280,
-    "name": "Arrocera La Catumbera",
+    "name": "Arrocera la Catumbera",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -10650,7 +10650,7 @@
   },
   {
     "id": 162281,
-    "name": "Arrocera La Querencia",
+    "name": "Arrocera la Querencia",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -10671,7 +10671,7 @@
   },
   {
     "id": 162282,
-    "name": "Totoral Del Sauce",
+    "name": "Totoral del Sauce",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -10776,7 +10776,7 @@
   },
   {
     "id": 162287,
-    "name": "Rossell Y Rius",
+    "name": "Rossell y Rius",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -10902,7 +10902,7 @@
   },
   {
     "id": 162293,
-    "name": "Ejido De Treinta Y Tres",
+    "name": "Ejido de Treinta y Tres",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -10965,7 +10965,7 @@
   },
   {
     "id": 162296,
-    "name": "Cerro De Pastoreo",
+    "name": "Cerro de Pastoreo",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -11070,7 +11070,7 @@
   },
   {
     "id": 162301,
-    "name": "Molles De Aigua",
+    "name": "Molles de Aigua",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -11091,7 +11091,7 @@
   },
   {
     "id": 162302,
-    "name": "Sauce Del Yi",
+    "name": "Sauce del Yi",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -11133,7 +11133,7 @@
   },
   {
     "id": 162304,
-    "name": "Rincon De Nazareth",
+    "name": "Rincon de Nazareth",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -11196,7 +11196,7 @@
   },
   {
     "id": 162307,
-    "name": "Real De Vera",
+    "name": "Real de Vera",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -11259,7 +11259,7 @@
   },
   {
     "id": 162310,
-    "name": "Chacras De Dolores",
+    "name": "Chacras de Dolores",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -11280,7 +11280,7 @@
   },
   {
     "id": 162311,
-    "name": "Rincon De Ruiz",
+    "name": "Rincon de Ruiz",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -11343,7 +11343,7 @@
   },
   {
     "id": 162314,
-    "name": "Paso De La Cruz",
+    "name": "Paso de la Cruz",
     "state_id": 3205,
     "state_code": "AR",
     "country_id": 235,
@@ -11427,7 +11427,7 @@
   },
   {
     "id": 162318,
-    "name": "Zanja Honda De Tranqueras",
+    "name": "Zanja Honda de Tranqueras",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -11511,7 +11511,7 @@
   },
   {
     "id": 162322,
-    "name": "Puntas De Molles",
+    "name": "Puntas de Molles",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -11532,7 +11532,7 @@
   },
   {
     "id": 162323,
-    "name": "Casa De Las Cronicas",
+    "name": "Casa de las Cronicas",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -11574,7 +11574,7 @@
   },
   {
     "id": 162325,
-    "name": "Cuchilla Del Carmen",
+    "name": "Cuchilla del Carmen",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -11595,7 +11595,7 @@
   },
   {
     "id": 162326,
-    "name": "Arrozal Treinta Y Tres",
+    "name": "Arrozal Treinta y Tres",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -11637,7 +11637,7 @@
   },
   {
     "id": 162328,
-    "name": "Palo A Pique",
+    "name": "Palo a Pique",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -11658,7 +11658,7 @@
   },
   {
     "id": 162329,
-    "name": "Costas De Cebollati",
+    "name": "Costas de Cebollati",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -11700,7 +11700,7 @@
   },
   {
     "id": 162331,
-    "name": "Sarandi Del Mataojo",
+    "name": "Sarandi del Mataojo",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -11721,7 +11721,7 @@
   },
   {
     "id": 162332,
-    "name": "Vejigas De San Ramon",
+    "name": "Vejigas de San Ramon",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -11742,7 +11742,7 @@
   },
   {
     "id": 162333,
-    "name": "Costa De Pando San Jacinto",
+    "name": "Costa de Pando San Jacinto",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -11763,7 +11763,7 @@
   },
   {
     "id": 162334,
-    "name": "Costa De Pando Olmos",
+    "name": "Costa de Pando Olmos",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -11826,7 +11826,7 @@
   },
   {
     "id": 162337,
-    "name": "Puerto De Los Botes",
+    "name": "Puerto de los Botes",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -11847,7 +11847,7 @@
   },
   {
     "id": 162338,
-    "name": "Puntas De Arroyo Negro",
+    "name": "Puntas de Arroyo Negro",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -11868,7 +11868,7 @@
   },
   {
     "id": 162339,
-    "name": "Ceramicas Del Sur",
+    "name": "Ceramicas del Sur",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -11910,7 +11910,7 @@
   },
   {
     "id": 162341,
-    "name": "Barrio La Vinchuca",
+    "name": "Barrio la Vinchuca",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -11931,7 +11931,7 @@
   },
   {
     "id": 162342,
-    "name": "Colinas De Carrasco",
+    "name": "Colinas de Carrasco",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -11952,7 +11952,7 @@
   },
   {
     "id": 162343,
-    "name": "Lomas De Carrasco",
+    "name": "Lomas de Carrasco",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -11973,7 +11973,7 @@
   },
   {
     "id": 162344,
-    "name": "Caserio Las Cañas",
+    "name": "Caserio las Cañas",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -11994,7 +11994,7 @@
   },
   {
     "id": 162345,
-    "name": "Villa El Tato",
+    "name": "Villa el Tato",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -12036,7 +12036,7 @@
   },
   {
     "id": 162347,
-    "name": "Barrio La Lucha",
+    "name": "Barrio la Lucha",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -12351,7 +12351,7 @@
   },
   {
     "id": 162362,
-    "name": "Port. De Hierro Y Campodonico",
+    "name": "Port. de Hierro y Campodonico",
     "state_id": 3205,
     "state_code": "AR",
     "country_id": 235,
@@ -12498,7 +12498,7 @@
   },
   {
     "id": 162369,
-    "name": "Cruz De Los Caminos",
+    "name": "Cruz de los Caminos",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -12582,7 +12582,7 @@
   },
   {
     "id": 162373,
-    "name": "Piedras De Afilar",
+    "name": "Piedras de Afilar",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -12750,7 +12750,7 @@
   },
   {
     "id": 162381,
-    "name": "Paso Del Lagunon",
+    "name": "Paso del Lagunon",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -12771,7 +12771,7 @@
   },
   {
     "id": 162382,
-    "name": "Parque Del Plata",
+    "name": "Parque del Plata",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -12855,7 +12855,7 @@
   },
   {
     "id": 162386,
-    "name": "Camino Al Paso Del Andaluz",
+    "name": "Camino Al Paso del Andaluz",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -12918,7 +12918,7 @@
   },
   {
     "id": 162389,
-    "name": "Pinares De Solymar",
+    "name": "Pinares de Solymar",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -12939,7 +12939,7 @@
   },
   {
     "id": 162390,
-    "name": "Bosque De Solymar",
+    "name": "Bosque de Solymar",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -12960,7 +12960,7 @@
   },
   {
     "id": 162391,
-    "name": "San Jose De Carrasco",
+    "name": "San Jose de Carrasco",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -13044,7 +13044,7 @@
   },
   {
     "id": 162395,
-    "name": "Paso De Pache",
+    "name": "Paso de Pache",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -13065,7 +13065,7 @@
   },
   {
     "id": 162396,
-    "name": "Montes De Solymar",
+    "name": "Montes de Solymar",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -13401,7 +13401,7 @@
   },
   {
     "id": 162412,
-    "name": "Estanque De Pando",
+    "name": "Estanque de Pando",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -13422,7 +13422,7 @@
   },
   {
     "id": 162413,
-    "name": "Quintas Del Bosque",
+    "name": "Quintas del Bosque",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -13590,7 +13590,7 @@
   },
   {
     "id": 162421,
-    "name": "Paso Del Cerro",
+    "name": "Paso del Cerro",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -13653,7 +13653,7 @@
   },
   {
     "id": 162424,
-    "name": "Quinta Los Horneros",
+    "name": "Quinta los Horneros",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -13695,7 +13695,7 @@
   },
   {
     "id": 162426,
-    "name": "Estacion Piedras De Afilar",
+    "name": "Estacion Piedras de Afilar",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -13758,7 +13758,7 @@
   },
   {
     "id": 162429,
-    "name": "Costa Y Guillamon",
+    "name": "Costa y Guillamon",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -13926,7 +13926,7 @@
   },
   {
     "id": 162437,
-    "name": "Paso De Los Novillos",
+    "name": "Paso de los Novillos",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -14052,7 +14052,7 @@
   },
   {
     "id": 162443,
-    "name": "Polanco Del Yi",
+    "name": "Polanco del Yi",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -14199,7 +14199,7 @@
   },
   {
     "id": 162450,
-    "name": "Caserio La Fundacion",
+    "name": "Caserio la Fundacion",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -14241,7 +14241,7 @@
   },
   {
     "id": 162452,
-    "name": "Sarandi De Navarro",
+    "name": "Sarandi de Navarro",
     "state_id": 3210,
     "state_code": "RN",
     "country_id": 235,
@@ -14409,7 +14409,7 @@
   },
   {
     "id": 162460,
-    "name": "Escuela De Agronomia",
+    "name": "Escuela de Agronomia",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -14451,7 +14451,7 @@
   },
   {
     "id": 162462,
-    "name": "Cuchilla De Peralta",
+    "name": "Cuchilla de Peralta",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -14514,7 +14514,7 @@
   },
   {
     "id": 162465,
-    "name": "San Gregorio De Polanco",
+    "name": "San Gregorio de Polanco",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -14556,7 +14556,7 @@
   },
   {
     "id": 162467,
-    "name": "Cerro De Las Cuentas",
+    "name": "Cerro de las Cuentas",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -14619,7 +14619,7 @@
   },
   {
     "id": 162470,
-    "name": "Osimani Y Llerena",
+    "name": "Osimani y Llerena",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -14766,7 +14766,7 @@
   },
   {
     "id": 162477,
-    "name": "Puntas De Valentin",
+    "name": "Puntas de Valentin",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -14976,7 +14976,7 @@
   },
   {
     "id": 162487,
-    "name": "Paso Del Parque Del Dayman",
+    "name": "Paso del Parque del Dayman",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -15186,7 +15186,7 @@
   },
   {
     "id": 162497,
-    "name": "Cuchilla Del Perdido",
+    "name": "Cuchilla del Perdido",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -15228,7 +15228,7 @@
   },
   {
     "id": 162499,
-    "name": "Santa Lucia Del Este",
+    "name": "Santa Lucia del Este",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -15312,7 +15312,7 @@
   },
   {
     "id": 162503,
-    "name": "Cuchilla Del Ombu",
+    "name": "Cuchilla del Ombu",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -15354,7 +15354,7 @@
   },
   {
     "id": 162505,
-    "name": "Villa Del Rosario",
+    "name": "Villa del Rosario",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -15375,7 +15375,7 @@
   },
   {
     "id": 162506,
-    "name": "Colinas De Solymar",
+    "name": "Colinas de Solymar",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -15417,7 +15417,7 @@
   },
   {
     "id": 162508,
-    "name": "Aeropuerto Internacional De Carrasco",
+    "name": "Aeropuerto Internacional de Carrasco",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -15522,7 +15522,7 @@
   },
   {
     "id": 162513,
-    "name": "Jardines De Pando",
+    "name": "Jardines de Pando",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -15732,7 +15732,7 @@
   },
   {
     "id": 162523,
-    "name": "Paso De La Cadena",
+    "name": "Paso de la Cadena",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -15774,7 +15774,7 @@
   },
   {
     "id": 162525,
-    "name": "Piedra Del Toro",
+    "name": "Piedra del Toro",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -15921,7 +15921,7 @@
   },
   {
     "id": 162532,
-    "name": "Arrocera Las Palmas",
+    "name": "Arrocera las Palmas",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -15963,7 +15963,7 @@
   },
   {
     "id": 162534,
-    "name": "Altos De La Tahona",
+    "name": "Altos de la Tahona",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -16005,7 +16005,7 @@
   },
   {
     "id": 162536,
-    "name": "Bañado De Medina",
+    "name": "Bañado de Medina",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -16152,7 +16152,7 @@
   },
   {
     "id": 162543,
-    "name": "Cerros De San Juan",
+    "name": "Cerros de San Juan",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -16236,7 +16236,7 @@
   },
   {
     "id": 162547,
-    "name": "Caserio El Cerro",
+    "name": "Caserio el Cerro",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -16362,7 +16362,7 @@
   },
   {
     "id": 162553,
-    "name": "Brisas Del Plata",
+    "name": "Brisas del Plata",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -16614,7 +16614,7 @@
   },
   {
     "id": 162565,
-    "name": "Laguna De Los Patos",
+    "name": "Laguna de los Patos",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -16677,7 +16677,7 @@
   },
   {
     "id": 162568,
-    "name": "Ombues De Oribe",
+    "name": "Ombues de Oribe",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -16782,7 +16782,7 @@
   },
   {
     "id": 162573,
-    "name": "Capilla Del Sauce",
+    "name": "Capilla del Sauce",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -16908,7 +16908,7 @@
   },
   {
     "id": 162579,
-    "name": "Gaetan (Cuchilla De Carbajal)",
+    "name": "Gaetan (Cuchilla de Carbajal)",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -16971,7 +16971,7 @@
   },
   {
     "id": 162582,
-    "name": "Barrio La Coronilla - Ancap",
+    "name": "Barrio la Coronilla - Ancap",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -16992,7 +16992,7 @@
   },
   {
     "id": 162583,
-    "name": "San Francisco De Las Sierras",
+    "name": "San Francisco de las Sierras",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -17055,7 +17055,7 @@
   },
   {
     "id": 162586,
-    "name": "19 De Junio",
+    "name": "19 de Junio",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -17076,7 +17076,7 @@
   },
   {
     "id": 162587,
-    "name": "Cañada Del Pueblo",
+    "name": "Cañada del Pueblo",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -17370,7 +17370,7 @@
   },
   {
     "id": 162601,
-    "name": "Guaviyu De Arapey",
+    "name": "Guaviyu de Arapey",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -17475,7 +17475,7 @@
   },
   {
     "id": 162606,
-    "name": "19 De Abril",
+    "name": "19 de Abril",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -17538,7 +17538,7 @@
   },
   {
     "id": 162609,
-    "name": "Ruta 37 Y 9",
+    "name": "Ruta 37 y 9",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -17601,7 +17601,7 @@
   },
   {
     "id": 162612,
-    "name": "Jose Batlle Y Ordoñez",
+    "name": "Jose Batlle y Ordoñez",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -17958,7 +17958,7 @@
   },
   {
     "id": 162629,
-    "name": "Termas De Guaviyu",
+    "name": "Termas de Guaviyu",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -17979,7 +17979,7 @@
   },
   {
     "id": 162630,
-    "name": "Lagos Del Norte",
+    "name": "Lagos del Norte",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -18084,7 +18084,7 @@
   },
   {
     "id": 162635,
-    "name": "Colonia El Ombu",
+    "name": "Colonia el Ombu",
     "state_id": 3210,
     "state_code": "RN",
     "country_id": 235,
@@ -18126,7 +18126,7 @@
   },
   {
     "id": 162637,
-    "name": "Paso De Las Piedras De Arerungua",
+    "name": "Paso de las Piedras de Arerungua",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -18252,7 +18252,7 @@
   },
   {
     "id": 162643,
-    "name": "Costas De Pereira - Rapetti",
+    "name": "Costas de Pereira - Rapetti",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -18357,7 +18357,7 @@
   },
   {
     "id": 162648,
-    "name": "Boca Del Rosario Oeste",
+    "name": "Boca del Rosario Oeste",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -18378,7 +18378,7 @@
   },
   {
     "id": 162649,
-    "name": "Palmares De La Coronilla",
+    "name": "Palmares de la Coronilla",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -18441,7 +18441,7 @@
   },
   {
     "id": 162652,
-    "name": "La Aguada Y Costa Azul",
+    "name": "La Aguada y Costa Azul",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -18483,7 +18483,7 @@
   },
   {
     "id": 162654,
-    "name": "Barra Del Chuy",
+    "name": "Barra del Chuy",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -18651,7 +18651,7 @@
   },
   {
     "id": 162662,
-    "name": "Punta Del Diablo",
+    "name": "Punta del Diablo",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -18672,7 +18672,7 @@
   },
   {
     "id": 162663,
-    "name": "Oceania Del Polonio",
+    "name": "Oceania del Polonio",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -18735,7 +18735,7 @@
   },
   {
     "id": 162666,
-    "name": "Colonia 18 De Julio",
+    "name": "Colonia 18 de Julio",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -18777,7 +18777,7 @@
   },
   {
     "id": 162668,
-    "name": "Termas Del Arapey",
+    "name": "Termas del Arapey",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -18945,7 +18945,7 @@
   },
   {
     "id": 162676,
-    "name": "Campo De Todos",
+    "name": "Campo de Todos",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -19008,7 +19008,7 @@
   },
   {
     "id": 162679,
-    "name": "Cerros De Vera",
+    "name": "Cerros de Vera",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -19071,7 +19071,7 @@
   },
   {
     "id": 162682,
-    "name": "Boca Del Cufre",
+    "name": "Boca del Cufre",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -19155,7 +19155,7 @@
   },
   {
     "id": 162686,
-    "name": "Tajamares De La Pedrera",
+    "name": "Tajamares de la Pedrera",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -19176,7 +19176,7 @@
   },
   {
     "id": 162687,
-    "name": "Arrocera Los Teros",
+    "name": "Arrocera los Teros",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -19218,7 +19218,7 @@
   },
   {
     "id": 162689,
-    "name": "Las Toscas De Caraguata",
+    "name": "Las Toscas de Caraguata",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -19260,7 +19260,7 @@
   },
   {
     "id": 162691,
-    "name": "Cruz De Los Caminos",
+    "name": "Cruz de los Caminos",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -19281,7 +19281,7 @@
   },
   {
     "id": 162692,
-    "name": "Arrocera Los Ceibos",
+    "name": "Arrocera los Ceibos",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -19491,7 +19491,7 @@
   },
   {
     "id": 162702,
-    "name": "Parque De Solymar",
+    "name": "Parque de Solymar",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -19533,7 +19533,7 @@
   },
   {
     "id": 162704,
-    "name": "Puntas De Cinco Sauces",
+    "name": "Puntas de Cinco Sauces",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -19575,7 +19575,7 @@
   },
   {
     "id": 162706,
-    "name": "Barra De Portezuelo",
+    "name": "Barra de Portezuelo",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -19680,7 +19680,7 @@
   },
   {
     "id": 162711,
-    "name": "San Sebastian De La Pedrera",
+    "name": "San Sebastian de la Pedrera",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -19827,7 +19827,7 @@
   },
   {
     "id": 162718,
-    "name": "Picada De Cuello",
+    "name": "Picada de Cuello",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -19869,7 +19869,7 @@
   },
   {
     "id": 162720,
-    "name": "Cerro De Pereira",
+    "name": "Cerro de Pereira",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -19911,7 +19911,7 @@
   },
   {
     "id": 162722,
-    "name": "Cuchilla De La Palma",
+    "name": "Cuchilla de la Palma",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -19974,7 +19974,7 @@
   },
   {
     "id": 162725,
-    "name": "Costas De Tres Cruces",
+    "name": "Costas de Tres Cruces",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -19995,7 +19995,7 @@
   },
   {
     "id": 162726,
-    "name": "Rincon De Giloca",
+    "name": "Rincon de Giloca",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20079,7 +20079,7 @@
   },
   {
     "id": 162730,
-    "name": "Rincon De La Laguna",
+    "name": "Rincon de la Laguna",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20121,7 +20121,7 @@
   },
   {
     "id": 162732,
-    "name": "Rincon De Zamora",
+    "name": "Rincon de Zamora",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20142,7 +20142,7 @@
   },
   {
     "id": 162733,
-    "name": "Paso De Las Flores",
+    "name": "Paso de las Flores",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20163,7 +20163,7 @@
   },
   {
     "id": 162734,
-    "name": "Cuchilla De Laureles",
+    "name": "Cuchilla de Laureles",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20184,7 +20184,7 @@
   },
   {
     "id": 162735,
-    "name": "Paso Del Medio",
+    "name": "Paso del Medio",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20205,7 +20205,7 @@
   },
   {
     "id": 162736,
-    "name": "Paso De Ceferino",
+    "name": "Paso de Ceferino",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20247,7 +20247,7 @@
   },
   {
     "id": 162738,
-    "name": "Paso De Las Carretas",
+    "name": "Paso de las Carretas",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20289,7 +20289,7 @@
   },
   {
     "id": 162740,
-    "name": "Bañado De Rocha",
+    "name": "Bañado de Rocha",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20415,7 +20415,7 @@
   },
   {
     "id": 162746,
-    "name": "Rincon De La Aldea",
+    "name": "Rincon de la Aldea",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20457,7 +20457,7 @@
   },
   {
     "id": 162748,
-    "name": "Rincon De La Bolsa",
+    "name": "Rincon de la Bolsa",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20499,7 +20499,7 @@
   },
   {
     "id": 162750,
-    "name": "Sauce De Tranqueras",
+    "name": "Sauce de Tranqueras",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20604,7 +20604,7 @@
   },
   {
     "id": 162755,
-    "name": "Cerros De Clara",
+    "name": "Cerros de Clara",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20667,7 +20667,7 @@
   },
   {
     "id": 162758,
-    "name": "Rincon De Los Machado",
+    "name": "Rincon de los Machado",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20709,7 +20709,7 @@
   },
   {
     "id": 162760,
-    "name": "Cerro Del Arbolito",
+    "name": "Cerro del Arbolito",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20751,7 +20751,7 @@
   },
   {
     "id": 162762,
-    "name": "Arroyo Del Medio",
+    "name": "Arroyo del Medio",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20856,7 +20856,7 @@
   },
   {
     "id": 162767,
-    "name": "Puntas De Laureles",
+    "name": "Puntas de Laureles",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20940,7 +20940,7 @@
   },
   {
     "id": 162771,
-    "name": "Rincon De Freitas",
+    "name": "Rincon de Freitas",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -20982,7 +20982,7 @@
   },
   {
     "id": 162773,
-    "name": "Cuchilla De La Casa De Piedra",
+    "name": "Cuchilla de la Casa de Piedra",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -21108,7 +21108,7 @@
   },
   {
     "id": 162779,
-    "name": "Paso De Perez",
+    "name": "Paso de Perez",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -21213,7 +21213,7 @@
   },
   {
     "id": 162784,
-    "name": "Paso Del Medio Las Palmas",
+    "name": "Paso del Medio las Palmas",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21234,7 +21234,7 @@
   },
   {
     "id": 162785,
-    "name": "Cuchilla De Ramirez",
+    "name": "Cuchilla de Ramirez",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21507,7 +21507,7 @@
   },
   {
     "id": 162798,
-    "name": "Puntas De Herrera",
+    "name": "Puntas de Herrera",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21528,7 +21528,7 @@
   },
   {
     "id": 162799,
-    "name": "Puntas De Malbajar",
+    "name": "Puntas de Malbajar",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21549,7 +21549,7 @@
   },
   {
     "id": 162800,
-    "name": "Paso De Aguirre",
+    "name": "Paso de Aguirre",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21612,7 +21612,7 @@
   },
   {
     "id": 162803,
-    "name": "Sarandi De Rio Negro",
+    "name": "Sarandi de Rio Negro",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21675,7 +21675,7 @@
   },
   {
     "id": 162806,
-    "name": "Higueras De Carpinteria",
+    "name": "Higueras de Carpinteria",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21696,7 +21696,7 @@
   },
   {
     "id": 162807,
-    "name": "Paso Real De Carpinteria",
+    "name": "Paso Real de Carpinteria",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21717,7 +21717,7 @@
   },
   {
     "id": 162808,
-    "name": "Cuchilla Del Rincon",
+    "name": "Cuchilla del Rincon",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21738,7 +21738,7 @@
   },
   {
     "id": 162809,
-    "name": "Arroyo De Los Perros",
+    "name": "Arroyo de los Perros",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21780,7 +21780,7 @@
   },
   {
     "id": 162811,
-    "name": "Puntas De Carpinteria",
+    "name": "Puntas de Carpinteria",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21801,7 +21801,7 @@
   },
   {
     "id": 162812,
-    "name": "Municipio De Durazno",
+    "name": "Municipio de Durazno",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21822,7 +21822,7 @@
   },
   {
     "id": 162813,
-    "name": "Sauce De Herrera",
+    "name": "Sauce de Herrera",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21927,7 +21927,7 @@
   },
   {
     "id": 162818,
-    "name": "Mariscala Del Carmen",
+    "name": "Mariscala del Carmen",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21969,7 +21969,7 @@
   },
   {
     "id": 162820,
-    "name": "Paso De Castro",
+    "name": "Paso de Castro",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -21990,7 +21990,7 @@
   },
   {
     "id": 162821,
-    "name": "Sauce Del Yi",
+    "name": "Sauce del Yi",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -22011,7 +22011,7 @@
   },
   {
     "id": 162822,
-    "name": "Tala De Mariscala",
+    "name": "Tala de Mariscala",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -22032,7 +22032,7 @@
   },
   {
     "id": 162823,
-    "name": "Sarandi De La China",
+    "name": "Sarandi de la China",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -22200,7 +22200,7 @@
   },
   {
     "id": 162831,
-    "name": "Costa De Cuadra",
+    "name": "Costa de Cuadra",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -22347,7 +22347,7 @@
   },
   {
     "id": 162838,
-    "name": "Molles De Quinteros",
+    "name": "Molles de Quinteros",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -22410,7 +22410,7 @@
   },
   {
     "id": 162841,
-    "name": "Chacras De Durazno",
+    "name": "Chacras de Durazno",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -22431,7 +22431,7 @@
   },
   {
     "id": 162842,
-    "name": "Rincon De Los Tapes",
+    "name": "Rincon de los Tapes",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -22452,7 +22452,7 @@
   },
   {
     "id": 162843,
-    "name": "Costas De Corrales",
+    "name": "Costas de Corrales",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22536,7 +22536,7 @@
   },
   {
     "id": 162847,
-    "name": "Sarandi De Gutierrez",
+    "name": "Sarandi de Gutierrez",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22557,7 +22557,7 @@
   },
   {
     "id": 162848,
-    "name": "Rincon De Cebollati",
+    "name": "Rincon de Cebollati",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22620,7 +22620,7 @@
   },
   {
     "id": 162851,
-    "name": "Rincon De Mariscala",
+    "name": "Rincon de Mariscala",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22641,7 +22641,7 @@
   },
   {
     "id": 162852,
-    "name": "Molles Del Sauce",
+    "name": "Molles del Sauce",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22662,7 +22662,7 @@
   },
   {
     "id": 162853,
-    "name": "Sauce De Olimar Chico",
+    "name": "Sauce de Olimar Chico",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22704,7 +22704,7 @@
   },
   {
     "id": 162855,
-    "name": "Molles De Cañada Grande",
+    "name": "Molles de Cañada Grande",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22725,7 +22725,7 @@
   },
   {
     "id": 162856,
-    "name": "Rincon De Silva",
+    "name": "Rincon de Silva",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22767,7 +22767,7 @@
   },
   {
     "id": 162858,
-    "name": "Paso De Mesa",
+    "name": "Paso de Mesa",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22851,7 +22851,7 @@
   },
   {
     "id": 162862,
-    "name": "Puntas De Barriga Negra",
+    "name": "Puntas de Barriga Negra",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22893,7 +22893,7 @@
   },
   {
     "id": 162864,
-    "name": "Paso De Los Troncos",
+    "name": "Paso de los Troncos",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22956,7 +22956,7 @@
   },
   {
     "id": 162867,
-    "name": "Puente De Marmaraja",
+    "name": "Puente de Marmaraja",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22977,7 +22977,7 @@
   },
   {
     "id": 162868,
-    "name": "Sauce De Aigua",
+    "name": "Sauce de Aigua",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -22998,7 +22998,7 @@
   },
   {
     "id": 162869,
-    "name": "Marco De Los Reyes",
+    "name": "Marco de los Reyes",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23124,7 +23124,7 @@
   },
   {
     "id": 162875,
-    "name": "Puntas De Polanco",
+    "name": "Puntas de Polanco",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23229,7 +23229,7 @@
   },
   {
     "id": 162880,
-    "name": "Costas Del Soldado",
+    "name": "Costas del Soldado",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23271,7 +23271,7 @@
   },
   {
     "id": 162882,
-    "name": "Puntas De Santa Lucia",
+    "name": "Puntas de Santa Lucia",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23292,7 +23292,7 @@
   },
   {
     "id": 162883,
-    "name": "Arroyo Del Medio",
+    "name": "Arroyo del Medio",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23313,7 +23313,7 @@
   },
   {
     "id": 162884,
-    "name": "Costa Del Lenguazo",
+    "name": "Costa del Lenguazo",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23355,7 +23355,7 @@
   },
   {
     "id": 162886,
-    "name": "Puntas Del Perdido",
+    "name": "Puntas del Perdido",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23502,7 +23502,7 @@
   },
   {
     "id": 162893,
-    "name": "Canteras Del Verdun",
+    "name": "Canteras del Verdun",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23628,7 +23628,7 @@
   },
   {
     "id": 162899,
-    "name": "Puntas De Los Chanchos",
+    "name": "Puntas de los Chanchos",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23670,7 +23670,7 @@
   },
   {
     "id": 162901,
-    "name": "Puntas De San Francisco",
+    "name": "Puntas de San Francisco",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23691,7 +23691,7 @@
   },
   {
     "id": 162902,
-    "name": "Abra De Zabaleta",
+    "name": "Abra de Zabaleta",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23817,7 +23817,7 @@
   },
   {
     "id": 162908,
-    "name": "Puntas De Vejigas",
+    "name": "Puntas de Vejigas",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23838,7 +23838,7 @@
   },
   {
     "id": 162909,
-    "name": "Puntas De Solis",
+    "name": "Puntas de Solis",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23859,7 +23859,7 @@
   },
   {
     "id": 162910,
-    "name": "Arroyo De Los Patos",
+    "name": "Arroyo de los Patos",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23880,7 +23880,7 @@
   },
   {
     "id": 162911,
-    "name": "Ombues De Bentancor",
+    "name": "Ombues de Bentancor",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23901,7 +23901,7 @@
   },
   {
     "id": 162912,
-    "name": "Barra De Los Chanchos",
+    "name": "Barra de los Chanchos",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -23943,7 +23943,7 @@
   },
   {
     "id": 162914,
-    "name": "Valle De Solis",
+    "name": "Valle de Solis",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -24069,7 +24069,7 @@
   },
   {
     "id": 162920,
-    "name": "Pueblo De Los Morochos",
+    "name": "Pueblo de los Morochos",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24090,7 +24090,7 @@
   },
   {
     "id": 162921,
-    "name": "Molles Del Pescado",
+    "name": "Molles del Pescado",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24132,7 +24132,7 @@
   },
   {
     "id": 162923,
-    "name": "Puntas De Illescas",
+    "name": "Puntas de Illescas",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24174,7 +24174,7 @@
   },
   {
     "id": 162925,
-    "name": "Paso Real De Mansavillagra",
+    "name": "Paso Real de Mansavillagra",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24195,7 +24195,7 @@
   },
   {
     "id": 162926,
-    "name": "Puntas De Mansavillagra",
+    "name": "Puntas de Mansavillagra",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24216,7 +24216,7 @@
   },
   {
     "id": 162927,
-    "name": "Puntas De Chamame",
+    "name": "Puntas de Chamame",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24279,7 +24279,7 @@
   },
   {
     "id": 162930,
-    "name": "Rincon Sauce Del Yi",
+    "name": "Rincon Sauce del Yi",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24300,7 +24300,7 @@
   },
   {
     "id": 162931,
-    "name": "Costa De Illescas",
+    "name": "Costa de Illescas",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24321,7 +24321,7 @@
   },
   {
     "id": 162932,
-    "name": "Barra Sauce De Mansavillagra",
+    "name": "Barra Sauce de Mansavillagra",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24447,7 +24447,7 @@
   },
   {
     "id": 162938,
-    "name": "San Pedro De Timote",
+    "name": "San Pedro de Timote",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24489,7 +24489,7 @@
   },
   {
     "id": 162940,
-    "name": "Puntas De Chamizo",
+    "name": "Puntas de Chamizo",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24510,7 +24510,7 @@
   },
   {
     "id": 162941,
-    "name": "Puntas De La Escobilla",
+    "name": "Puntas de la Escobilla",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24531,7 +24531,7 @@
   },
   {
     "id": 162942,
-    "name": "Costas Del Amarillo",
+    "name": "Costas del Amarillo",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24636,7 +24636,7 @@
   },
   {
     "id": 162947,
-    "name": "Puntas Del Arroyo Latorre",
+    "name": "Puntas del Arroyo Latorre",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24657,7 +24657,7 @@
   },
   {
     "id": 162948,
-    "name": "Costas Del Santa Lucia Grande",
+    "name": "Costas del Santa Lucia Grande",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24678,7 +24678,7 @@
   },
   {
     "id": 162949,
-    "name": "Barra Molles Del Timote",
+    "name": "Barra Molles del Timote",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24699,7 +24699,7 @@
   },
   {
     "id": 162950,
-    "name": "Costa Del Tala",
+    "name": "Costa del Tala",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24720,7 +24720,7 @@
   },
   {
     "id": 162951,
-    "name": "Tala De Castro",
+    "name": "Tala de Castro",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24762,7 +24762,7 @@
   },
   {
     "id": 162953,
-    "name": "Molles Del Timote",
+    "name": "Molles del Timote",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24825,7 +24825,7 @@
   },
   {
     "id": 162956,
-    "name": "Pantanoso De Castro",
+    "name": "Pantanoso de Castro",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24867,7 +24867,7 @@
   },
   {
     "id": 162958,
-    "name": "Arroyo De Los Negros",
+    "name": "Arroyo de los Negros",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -24951,7 +24951,7 @@
   },
   {
     "id": 162962,
-    "name": "Costa De La Cruz",
+    "name": "Costa de la Cruz",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25014,7 +25014,7 @@
   },
   {
     "id": 162965,
-    "name": "Cerros De Florida",
+    "name": "Cerros de Florida",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25056,7 +25056,7 @@
   },
   {
     "id": 162967,
-    "name": "Costas De Arias",
+    "name": "Costas de Arias",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25077,7 +25077,7 @@
   },
   {
     "id": 162968,
-    "name": "Costas De Chamizo Grande",
+    "name": "Costas de Chamizo Grande",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25119,7 +25119,7 @@
   },
   {
     "id": 162970,
-    "name": "Costa De Arias",
+    "name": "Costa de Arias",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25161,7 +25161,7 @@
   },
   {
     "id": 162972,
-    "name": "Costas De Chamizo",
+    "name": "Costas de Chamizo",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25182,7 +25182,7 @@
   },
   {
     "id": 162973,
-    "name": "Rincon De Los Camilos",
+    "name": "Rincon de los Camilos",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25203,7 +25203,7 @@
   },
   {
     "id": 162974,
-    "name": "Sauce De Villanueva",
+    "name": "Sauce de Villanueva",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25245,7 +25245,7 @@
   },
   {
     "id": 162976,
-    "name": "Costas De Maciel",
+    "name": "Costas de Maciel",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25266,7 +25266,7 @@
   },
   {
     "id": 162977,
-    "name": "Tala De Maciel",
+    "name": "Tala de Maciel",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25329,7 +25329,7 @@
   },
   {
     "id": 162980,
-    "name": "Costa De Parana",
+    "name": "Costa de Parana",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25350,7 +25350,7 @@
   },
   {
     "id": 162981,
-    "name": "Puntas De Sarandi",
+    "name": "Puntas de Sarandi",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25413,7 +25413,7 @@
   },
   {
     "id": 162984,
-    "name": "Sauce De Maciel",
+    "name": "Sauce de Maciel",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25434,7 +25434,7 @@
   },
   {
     "id": 162985,
-    "name": "Puntas De Sauce De Maciel",
+    "name": "Puntas de Sauce de Maciel",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25455,7 +25455,7 @@
   },
   {
     "id": 162986,
-    "name": "Corral De Piedra",
+    "name": "Corral de Piedra",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25476,7 +25476,7 @@
   },
   {
     "id": 162987,
-    "name": "Cerro De La Macana",
+    "name": "Cerro de la Macana",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25539,7 +25539,7 @@
   },
   {
     "id": 162990,
-    "name": "Costas Del Pintado",
+    "name": "Costas del Pintado",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25560,7 +25560,7 @@
   },
   {
     "id": 162991,
-    "name": "Puntas De Calleros",
+    "name": "Puntas de Calleros",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25581,7 +25581,7 @@
   },
   {
     "id": 162992,
-    "name": "Chacras De Florida",
+    "name": "Chacras de Florida",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25623,7 +25623,7 @@
   },
   {
     "id": 162994,
-    "name": "Chacras Del Pintado",
+    "name": "Chacras del Pintado",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25665,7 +25665,7 @@
   },
   {
     "id": 162996,
-    "name": "Paso De Los Novillos",
+    "name": "Paso de los Novillos",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25728,7 +25728,7 @@
   },
   {
     "id": 162999,
-    "name": "Costas De Santa Lucia Chico",
+    "name": "Costas de Santa Lucia Chico",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25749,7 +25749,7 @@
   },
   {
     "id": 163000,
-    "name": "Rincon De Vignoli",
+    "name": "Rincon de Vignoli",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25791,7 +25791,7 @@
   },
   {
     "id": 163002,
-    "name": "Puente De Mendoza",
+    "name": "Puente de Mendoza",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -25833,7 +25833,7 @@
   },
   {
     "id": 163004,
-    "name": "Puntas Del Corral De Piedra",
+    "name": "Puntas del Corral de Piedra",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -25875,7 +25875,7 @@
   },
   {
     "id": 163006,
-    "name": "Cuchilla De Villasboas",
+    "name": "Cuchilla de Villasboas",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -25917,7 +25917,7 @@
   },
   {
     "id": 163008,
-    "name": "Chacras De Borghi",
+    "name": "Chacras de Borghi",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -25959,7 +25959,7 @@
   },
   {
     "id": 163010,
-    "name": "Puntas De Chamanga",
+    "name": "Puntas de Chamanga",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -26001,7 +26001,7 @@
   },
   {
     "id": 163012,
-    "name": "Talas De Maciel",
+    "name": "Talas de Maciel",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -26022,7 +26022,7 @@
   },
   {
     "id": 163013,
-    "name": "Costas De San Jose",
+    "name": "Costas de San Jose",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -26064,7 +26064,7 @@
   },
   {
     "id": 163015,
-    "name": "San Gregorio De Flores",
+    "name": "San Gregorio de Flores",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -26085,7 +26085,7 @@
   },
   {
     "id": 163016,
-    "name": "Costas Del Tala",
+    "name": "Costas del Tala",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -26148,7 +26148,7 @@
   },
   {
     "id": 163019,
-    "name": "Rincon Del Palacio",
+    "name": "Rincon del Palacio",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -26232,7 +26232,7 @@
   },
   {
     "id": 163023,
-    "name": "Puntas De Marincho",
+    "name": "Puntas de Marincho",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -26295,7 +26295,7 @@
   },
   {
     "id": 163026,
-    "name": "Puntas De Sarandi",
+    "name": "Puntas de Sarandi",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -26337,7 +26337,7 @@
   },
   {
     "id": 163028,
-    "name": "Puntas Del Sauce",
+    "name": "Puntas del Sauce",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -26400,7 +26400,7 @@
   },
   {
     "id": 163031,
-    "name": "Puntas De San Jose",
+    "name": "Puntas de San Jose",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -26442,7 +26442,7 @@
   },
   {
     "id": 163033,
-    "name": "Paso  De Lugo",
+    "name": "Paso  de Lugo",
     "state_id": 3203,
     "state_code": "FS",
     "country_id": 235,
@@ -26484,7 +26484,7 @@
   },
   {
     "id": 163035,
-    "name": "Paso De Mas",
+    "name": "Paso de Mas",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -26526,7 +26526,7 @@
   },
   {
     "id": 163037,
-    "name": "Arroyo De La Virgen",
+    "name": "Arroyo de la Virgen",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -26547,7 +26547,7 @@
   },
   {
     "id": 163038,
-    "name": "Puntas De Cagancha",
+    "name": "Puntas de Cagancha",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -26568,7 +26568,7 @@
   },
   {
     "id": 163039,
-    "name": "Cuchilla Del Vichadero",
+    "name": "Cuchilla del Vichadero",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -26589,7 +26589,7 @@
   },
   {
     "id": 163040,
-    "name": "Rincon De Albano",
+    "name": "Rincon de Albano",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -26673,7 +26673,7 @@
   },
   {
     "id": 163044,
-    "name": "Puntas De Chamizo",
+    "name": "Puntas de Chamizo",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -26778,7 +26778,7 @@
   },
   {
     "id": 163049,
-    "name": "Paso Del Rey",
+    "name": "Paso del Rey",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -26799,7 +26799,7 @@
   },
   {
     "id": 163050,
-    "name": "Costas Del Sauce",
+    "name": "Costas del Sauce",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -26925,7 +26925,7 @@
   },
   {
     "id": 163056,
-    "name": "Paso Del Carreton",
+    "name": "Paso del Carreton",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27030,7 +27030,7 @@
   },
   {
     "id": 163061,
-    "name": "Cruz De Los Caminos",
+    "name": "Cruz de los Caminos",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27051,7 +27051,7 @@
   },
   {
     "id": 163062,
-    "name": "Paso De Cames",
+    "name": "Paso de Cames",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27072,7 +27072,7 @@
   },
   {
     "id": 163063,
-    "name": "Rincon De Arias",
+    "name": "Rincon de Arias",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27219,7 +27219,7 @@
   },
   {
     "id": 163070,
-    "name": "Puntas De Laurel",
+    "name": "Puntas de Laurel",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27282,7 +27282,7 @@
   },
   {
     "id": 163073,
-    "name": "Rincon De La Torre",
+    "name": "Rincon de la Torre",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27303,7 +27303,7 @@
   },
   {
     "id": 163074,
-    "name": "Minuano Y Sauce",
+    "name": "Minuano y Sauce",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -27324,7 +27324,7 @@
   },
   {
     "id": 163075,
-    "name": "Tala De Pereira",
+    "name": "Tala de Pereira",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27345,7 +27345,7 @@
   },
   {
     "id": 163076,
-    "name": "Puntas De Gregorio",
+    "name": "Puntas de Gregorio",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27450,7 +27450,7 @@
   },
   {
     "id": 163081,
-    "name": "Costa Del Mauricio",
+    "name": "Costa del Mauricio",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27471,7 +27471,7 @@
   },
   {
     "id": 163082,
-    "name": "Rincon De Buschental",
+    "name": "Rincon de Buschental",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27492,7 +27492,7 @@
   },
   {
     "id": 163083,
-    "name": "Orillas Del Plata",
+    "name": "Orillas del Plata",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27513,7 +27513,7 @@
   },
   {
     "id": 163084,
-    "name": "Puntas De Tropa Vieja",
+    "name": "Puntas de Tropa Vieja",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27534,7 +27534,7 @@
   },
   {
     "id": 163085,
-    "name": "Paso Del Guaycuru",
+    "name": "Paso del Guaycuru",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27723,7 +27723,7 @@
   },
   {
     "id": 163094,
-    "name": "Rincon De Cufre",
+    "name": "Rincon de Cufre",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27744,7 +27744,7 @@
   },
   {
     "id": 163095,
-    "name": "Rincon De Arazati",
+    "name": "Rincon de Arazati",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27786,7 +27786,7 @@
   },
   {
     "id": 163097,
-    "name": "Paso De Las Piedras",
+    "name": "Paso de las Piedras",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -27807,7 +27807,7 @@
   },
   {
     "id": 163098,
-    "name": "Costa De Rosario",
+    "name": "Costa de Rosario",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -27828,7 +27828,7 @@
   },
   {
     "id": 163099,
-    "name": "Paso De La Quinta",
+    "name": "Paso de la Quinta",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -27996,7 +27996,7 @@
   },
   {
     "id": 163107,
-    "name": "Costas De San Juan",
+    "name": "Costas de San Juan",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28017,7 +28017,7 @@
   },
   {
     "id": 163108,
-    "name": "Puntas De San Juan",
+    "name": "Puntas de San Juan",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28122,7 +28122,7 @@
   },
   {
     "id": 163113,
-    "name": "Costas De Polonia",
+    "name": "Costas de Polonia",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28248,7 +28248,7 @@
   },
   {
     "id": 163119,
-    "name": "Puntas Del Sauce",
+    "name": "Puntas del Sauce",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28269,7 +28269,7 @@
   },
   {
     "id": 163120,
-    "name": "Puntas De Melo",
+    "name": "Puntas de Melo",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28311,7 +28311,7 @@
   },
   {
     "id": 163122,
-    "name": "Costa De Colla Al Este",
+    "name": "Costa de Colla Al Este",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28332,7 +28332,7 @@
   },
   {
     "id": 163123,
-    "name": "Costa Del Navarro",
+    "name": "Costa del Navarro",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28353,7 +28353,7 @@
   },
   {
     "id": 163124,
-    "name": "Rosario Y Colla",
+    "name": "Rosario y Colla",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28416,7 +28416,7 @@
   },
   {
     "id": 163127,
-    "name": "Picada De Benitez",
+    "name": "Picada de Benitez",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28563,7 +28563,7 @@
   },
   {
     "id": 163134,
-    "name": "Rincon Del Rey",
+    "name": "Rincon del Rey",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28647,7 +28647,7 @@
   },
   {
     "id": 163138,
-    "name": "Molles De Miguelete",
+    "name": "Molles de Miguelete",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28668,7 +28668,7 @@
   },
   {
     "id": 163139,
-    "name": "Miguelete De Conchillas",
+    "name": "Miguelete de Conchillas",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28689,7 +28689,7 @@
   },
   {
     "id": 163140,
-    "name": "Puntas De Juan Gonzalez",
+    "name": "Puntas de Juan Gonzalez",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28731,7 +28731,7 @@
   },
   {
     "id": 163142,
-    "name": "Cerro De Las Armas",
+    "name": "Cerro de las Armas",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28815,7 +28815,7 @@
   },
   {
     "id": 163146,
-    "name": "Minas De Narancio",
+    "name": "Minas de Narancio",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28899,7 +28899,7 @@
   },
   {
     "id": 163150,
-    "name": "Puntas De San Pedro",
+    "name": "Puntas de San Pedro",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28920,7 +28920,7 @@
   },
   {
     "id": 163151,
-    "name": "San Pedro De Arriba",
+    "name": "San Pedro de Arriba",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -28941,7 +28941,7 @@
   },
   {
     "id": 163152,
-    "name": "Piedra De Los Indios",
+    "name": "Piedra de los Indios",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -29004,7 +29004,7 @@
   },
   {
     "id": 163155,
-    "name": "Puntas Del Riachuelo",
+    "name": "Puntas del Riachuelo",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -29025,7 +29025,7 @@
   },
   {
     "id": 163156,
-    "name": "Costa De Tarariras",
+    "name": "Costa de Tarariras",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -29046,7 +29046,7 @@
   },
   {
     "id": 163157,
-    "name": "San Luis De Tarariras",
+    "name": "San Luis de Tarariras",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -29193,7 +29193,7 @@
   },
   {
     "id": 163164,
-    "name": "Viboras Y Vacas",
+    "name": "Viboras y Vacas",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -29256,7 +29256,7 @@
   },
   {
     "id": 163167,
-    "name": "Costa De Vacas",
+    "name": "Costa de Vacas",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -29298,7 +29298,7 @@
   },
   {
     "id": 163169,
-    "name": "Costas De Juan Gonzalez",
+    "name": "Costas de Juan Gonzalez",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -29403,7 +29403,7 @@
   },
   {
     "id": 163174,
-    "name": "Martin Chico De Conchillas",
+    "name": "Martin Chico de Conchillas",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -29613,7 +29613,7 @@
   },
   {
     "id": 163184,
-    "name": "Puntas Del Tala",
+    "name": "Puntas del Tala",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -29697,7 +29697,7 @@
   },
   {
     "id": 163188,
-    "name": "Costas Del Perdido",
+    "name": "Costas del Perdido",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -29718,7 +29718,7 @@
   },
   {
     "id": 163189,
-    "name": "Puntas De Durazno",
+    "name": "Puntas de Durazno",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -29760,7 +29760,7 @@
   },
   {
     "id": 163191,
-    "name": "Bajos Del Perdido",
+    "name": "Bajos del Perdido",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -29781,7 +29781,7 @@
   },
   {
     "id": 163192,
-    "name": "Altos Del Perdido",
+    "name": "Altos del Perdido",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -29823,7 +29823,7 @@
   },
   {
     "id": 163194,
-    "name": "Cueva Del Tigre",
+    "name": "Cueva del Tigre",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -29844,7 +29844,7 @@
   },
   {
     "id": 163195,
-    "name": "Puntas De San Salvador",
+    "name": "Puntas de San Salvador",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -29865,7 +29865,7 @@
   },
   {
     "id": 163196,
-    "name": "Lata Del Perdido",
+    "name": "Lata del Perdido",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -29886,7 +29886,7 @@
   },
   {
     "id": 163197,
-    "name": "Rincon De Cololo",
+    "name": "Rincon de Cololo",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -30012,7 +30012,7 @@
   },
   {
     "id": 163203,
-    "name": "Grito De Asencio",
+    "name": "Grito de Asencio",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -30180,7 +30180,7 @@
   },
   {
     "id": 163211,
-    "name": "Cuchilla Del Corralito",
+    "name": "Cuchilla del Corralito",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -30243,7 +30243,7 @@
   },
   {
     "id": 163214,
-    "name": "Arroyo Del Medio",
+    "name": "Arroyo del Medio",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -30306,7 +30306,7 @@
   },
   {
     "id": 163217,
-    "name": "Chacras De Mercedes",
+    "name": "Chacras de Mercedes",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -30453,7 +30453,7 @@
   },
   {
     "id": 163224,
-    "name": "Paso De La Arena",
+    "name": "Paso de la Arena",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -30474,7 +30474,7 @@
   },
   {
     "id": 163225,
-    "name": "Paso De Ramos",
+    "name": "Paso de Ramos",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -30495,7 +30495,7 @@
   },
   {
     "id": 163226,
-    "name": "Costa Del Aguila",
+    "name": "Costa del Aguila",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -30516,7 +30516,7 @@
   },
   {
     "id": 163227,
-    "name": "Cuatro Bocas De Buena Vista",
+    "name": "Cuatro Bocas de Buena Vista",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -30558,7 +30558,7 @@
   },
   {
     "id": 163229,
-    "name": "Puntas De Arenales",
+    "name": "Puntas de Arenales",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -30663,7 +30663,7 @@
   },
   {
     "id": 163234,
-    "name": "Puntas De Averias",
+    "name": "Puntas de Averias",
     "state_id": 3210,
     "state_code": "RN",
     "country_id": 235,
@@ -30747,7 +30747,7 @@
   },
   {
     "id": 163238,
-    "name": "Paso De Soca",
+    "name": "Paso de Soca",
     "state_id": 3210,
     "state_code": "RN",
     "country_id": 235,
@@ -30852,7 +30852,7 @@
   },
   {
     "id": 163243,
-    "name": "Paso De Balbuena",
+    "name": "Paso de Balbuena",
     "state_id": 3210,
     "state_code": "RN",
     "country_id": 235,
@@ -30936,7 +30936,7 @@
   },
   {
     "id": 163247,
-    "name": "Molles De Porrua",
+    "name": "Molles de Porrua",
     "state_id": 3210,
     "state_code": "RN",
     "country_id": 235,
@@ -31020,7 +31020,7 @@
   },
   {
     "id": 163251,
-    "name": "Valle De Soba",
+    "name": "Valle de Soba",
     "state_id": 3210,
     "state_code": "RN",
     "country_id": 235,
@@ -31041,7 +31041,7 @@
   },
   {
     "id": 163252,
-    "name": "Paso De Leopoldo",
+    "name": "Paso de Leopoldo",
     "state_id": 3210,
     "state_code": "RN",
     "country_id": 235,
@@ -31125,7 +31125,7 @@
   },
   {
     "id": 163256,
-    "name": "Paso De Los Cobres",
+    "name": "Paso de los Cobres",
     "state_id": 3210,
     "state_code": "RN",
     "country_id": 235,
@@ -31587,7 +31587,7 @@
   },
   {
     "id": 163278,
-    "name": "Puntas De Buricayupi",
+    "name": "Puntas de Buricayupi",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -31629,7 +31629,7 @@
   },
   {
     "id": 163280,
-    "name": "Sauce Del Buricayupi",
+    "name": "Sauce del Buricayupi",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -31692,7 +31692,7 @@
   },
   {
     "id": 163283,
-    "name": "Paso De Los Carros",
+    "name": "Paso de los Carros",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -31839,7 +31839,7 @@
   },
   {
     "id": 163290,
-    "name": "Puntas De Bacacua",
+    "name": "Puntas de Bacacua",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -31944,7 +31944,7 @@
   },
   {
     "id": 163295,
-    "name": "Rincon Del Indio",
+    "name": "Rincon del Indio",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -32091,7 +32091,7 @@
   },
   {
     "id": 163302,
-    "name": "Palmar Del Quebracho",
+    "name": "Palmar del Quebracho",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -32112,7 +32112,7 @@
   },
   {
     "id": 163303,
-    "name": "Guaviyu De Quebracho",
+    "name": "Guaviyu de Quebracho",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -32133,7 +32133,7 @@
   },
   {
     "id": 163304,
-    "name": "Sauce Del Queguay",
+    "name": "Sauce del Queguay",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -32154,7 +32154,7 @@
   },
   {
     "id": 163305,
-    "name": "Sauce De Abajo",
+    "name": "Sauce de Abajo",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -32196,7 +32196,7 @@
   },
   {
     "id": 163307,
-    "name": "Puntas De Las Isletas",
+    "name": "Puntas de las Isletas",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -32301,7 +32301,7 @@
   },
   {
     "id": 163312,
-    "name": "Puntas De Cangue",
+    "name": "Puntas de Cangue",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -32343,7 +32343,7 @@
   },
   {
     "id": 163314,
-    "name": "Costa De Sacra",
+    "name": "Costa de Sacra",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -32469,7 +32469,7 @@
   },
   {
     "id": 163320,
-    "name": "Corral De Piedra",
+    "name": "Corral de Piedra",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -32511,7 +32511,7 @@
   },
   {
     "id": 163322,
-    "name": "Zanja Del Tigre",
+    "name": "Zanja del Tigre",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -32574,7 +32574,7 @@
   },
   {
     "id": 163325,
-    "name": "Paso Del Potrero",
+    "name": "Paso del Potrero",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -32637,7 +32637,7 @@
   },
   {
     "id": 163328,
-    "name": "Paso Del Tapado",
+    "name": "Paso del Tapado",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -32679,7 +32679,7 @@
   },
   {
     "id": 163330,
-    "name": "Paso Nuevo Del Arapey",
+    "name": "Paso Nuevo del Arapey",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -32763,7 +32763,7 @@
   },
   {
     "id": 163334,
-    "name": "Zanja De Alcain",
+    "name": "Zanja de Alcain",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -32931,7 +32931,7 @@
   },
   {
     "id": 163342,
-    "name": "Cerrilladas De Saucedo",
+    "name": "Cerrilladas de Saucedo",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -32952,7 +32952,7 @@
   },
   {
     "id": 163343,
-    "name": "Talas De Itapebi",
+    "name": "Talas de Itapebi",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -33078,7 +33078,7 @@
   },
   {
     "id": 163349,
-    "name": "Chacras De Constitucion",
+    "name": "Chacras de Constitucion",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -33351,7 +33351,7 @@
   },
   {
     "id": 163362,
-    "name": "Paso De Ramos",
+    "name": "Paso de Ramos",
     "state_id": 3205,
     "state_code": "AR",
     "country_id": 235,
@@ -33414,7 +33414,7 @@
   },
   {
     "id": 163365,
-    "name": "Sarandi De Cuaro",
+    "name": "Sarandi de Cuaro",
     "state_id": 3205,
     "state_code": "AR",
     "country_id": 235,
@@ -33477,7 +33477,7 @@
   },
   {
     "id": 163368,
-    "name": "Paso De Leon",
+    "name": "Paso de Leon",
     "state_id": 3205,
     "state_code": "AR",
     "country_id": 235,
@@ -33582,7 +33582,7 @@
   },
   {
     "id": 163373,
-    "name": "Sarandi De Yacuy",
+    "name": "Sarandi de Yacuy",
     "state_id": 3205,
     "state_code": "AR",
     "country_id": 235,
@@ -33666,7 +33666,7 @@
   },
   {
     "id": 163377,
-    "name": "Paso De Frontera",
+    "name": "Paso de Frontera",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -33687,7 +33687,7 @@
   },
   {
     "id": 163378,
-    "name": "Paso Del Puerto",
+    "name": "Paso del Puerto",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -33750,7 +33750,7 @@
   },
   {
     "id": 163381,
-    "name": "Paso De Arriera",
+    "name": "Paso de Arriera",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -33771,7 +33771,7 @@
   },
   {
     "id": 163382,
-    "name": "Pueblo De Los Santos",
+    "name": "Pueblo de los Santos",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -33834,7 +33834,7 @@
   },
   {
     "id": 163385,
-    "name": "Cruz De San Pedro",
+    "name": "Cruz de San Pedro",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -33918,7 +33918,7 @@
   },
   {
     "id": 163389,
-    "name": "Rincon De Rodriguez",
+    "name": "Rincon de Rodriguez",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -33939,7 +33939,7 @@
   },
   {
     "id": 163390,
-    "name": "Rincon De Amarillo",
+    "name": "Rincon de Amarillo",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -33960,7 +33960,7 @@
   },
   {
     "id": 163391,
-    "name": "Rincon De Yaguari",
+    "name": "Rincon de Yaguari",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34023,7 +34023,7 @@
   },
   {
     "id": 163394,
-    "name": "Chirca De Caraguata",
+    "name": "Chirca de Caraguata",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34044,7 +34044,7 @@
   },
   {
     "id": 163395,
-    "name": "Puntas De Abrojal",
+    "name": "Puntas de Abrojal",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34191,7 +34191,7 @@
   },
   {
     "id": 163402,
-    "name": "Puntas Del Yaguari",
+    "name": "Puntas del Yaguari",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34296,7 +34296,7 @@
   },
   {
     "id": 163407,
-    "name": "Coronilla De Corrales",
+    "name": "Coronilla de Corrales",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34380,7 +34380,7 @@
   },
   {
     "id": 163411,
-    "name": "Minas De Zapucay",
+    "name": "Minas de Zapucay",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34443,7 +34443,7 @@
   },
   {
     "id": 163414,
-    "name": "Cuchilla De Yaguari",
+    "name": "Cuchilla de Yaguari",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34548,7 +34548,7 @@
   },
   {
     "id": 163419,
-    "name": "Paso Del Tapado",
+    "name": "Paso del Tapado",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34569,7 +34569,7 @@
   },
   {
     "id": 163420,
-    "name": "Puntas De Corrales",
+    "name": "Puntas de Corrales",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34590,7 +34590,7 @@
   },
   {
     "id": 163421,
-    "name": "Paso De La Calera",
+    "name": "Paso de la Calera",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34611,7 +34611,7 @@
   },
   {
     "id": 163422,
-    "name": "Paso De Gaire",
+    "name": "Paso de Gaire",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34632,7 +34632,7 @@
   },
   {
     "id": 163423,
-    "name": "Rincon De Diniz",
+    "name": "Rincon de Diniz",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34653,7 +34653,7 @@
   },
   {
     "id": 163424,
-    "name": "Rincon De Roland",
+    "name": "Rincon de Roland",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34695,7 +34695,7 @@
   },
   {
     "id": 163426,
-    "name": "Costas De Cuñapiru",
+    "name": "Costas de Cuñapiru",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34716,7 +34716,7 @@
   },
   {
     "id": 163427,
-    "name": "Minas De Cuñapiru (Usinas)",
+    "name": "Minas de Cuñapiru (Usinas)",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34779,7 +34779,7 @@
   },
   {
     "id": 163430,
-    "name": "Rincon De Los Castillos",
+    "name": "Rincon de los Castillos",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34800,7 +34800,7 @@
   },
   {
     "id": 163431,
-    "name": "Rincon De Tres Cerros",
+    "name": "Rincon de Tres Cerros",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34905,7 +34905,7 @@
   },
   {
     "id": 163436,
-    "name": "Cuchilla De Tres Cerros",
+    "name": "Cuchilla de Tres Cerros",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34926,7 +34926,7 @@
   },
   {
     "id": 163437,
-    "name": "Puntas De Cuñapiru",
+    "name": "Puntas de Cuñapiru",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34947,7 +34947,7 @@
   },
   {
     "id": 163438,
-    "name": "Paso De Ataques",
+    "name": "Paso de Ataques",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -34989,7 +34989,7 @@
   },
   {
     "id": 163440,
-    "name": "Rincon De Moraes",
+    "name": "Rincon de Moraes",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -35052,7 +35052,7 @@
   },
   {
     "id": 163443,
-    "name": "Sauce De Batovi",
+    "name": "Sauce de Batovi",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -35094,7 +35094,7 @@
   },
   {
     "id": 163445,
-    "name": "Puntas Del Sauzal",
+    "name": "Puntas del Sauzal",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -35136,7 +35136,7 @@
   },
   {
     "id": 163447,
-    "name": "Barra De Ataques",
+    "name": "Barra de Ataques",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -35157,7 +35157,7 @@
   },
   {
     "id": 163448,
-    "name": "Paso De La Arena",
+    "name": "Paso de la Arena",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -35262,7 +35262,7 @@
   },
   {
     "id": 163453,
-    "name": "Sarandi De Yaguaron",
+    "name": "Sarandi de Yaguaron",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35283,7 +35283,7 @@
   },
   {
     "id": 163454,
-    "name": "Picada De Maya",
+    "name": "Picada de Maya",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35346,7 +35346,7 @@
   },
   {
     "id": 163457,
-    "name": "Puntas Del Sauce",
+    "name": "Puntas del Sauce",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35430,7 +35430,7 @@
   },
   {
     "id": 163461,
-    "name": "Cañada De Santos",
+    "name": "Cañada de Santos",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35451,7 +35451,7 @@
   },
   {
     "id": 163462,
-    "name": "Barra Del Sauce",
+    "name": "Barra del Sauce",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35472,7 +35472,7 @@
   },
   {
     "id": 163463,
-    "name": "Picada De Salome",
+    "name": "Picada de Salome",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35493,7 +35493,7 @@
   },
   {
     "id": 163464,
-    "name": "Barra Del Tacuari",
+    "name": "Barra del Tacuari",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35598,7 +35598,7 @@
   },
   {
     "id": 163469,
-    "name": "Falda De Sierra De Los Rios",
+    "name": "Falda de Sierra de los Rios",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35640,7 +35640,7 @@
   },
   {
     "id": 163471,
-    "name": "Rincon De Paiva",
+    "name": "Rincon de Paiva",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35766,7 +35766,7 @@
   },
   {
     "id": 163477,
-    "name": "Corral De Piedra",
+    "name": "Corral de Piedra",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35787,7 +35787,7 @@
   },
   {
     "id": 163478,
-    "name": "Puntas De Amarillo",
+    "name": "Puntas de Amarillo",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35808,7 +35808,7 @@
   },
   {
     "id": 163479,
-    "name": "Sarandi De Barcelo",
+    "name": "Sarandi de Barcelo",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35850,7 +35850,7 @@
   },
   {
     "id": 163481,
-    "name": "Cuchilla Del Paraiso",
+    "name": "Cuchilla del Paraiso",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35871,7 +35871,7 @@
   },
   {
     "id": 163482,
-    "name": "Rincon De Los Olivera",
+    "name": "Rincon de los Olivera",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35892,7 +35892,7 @@
   },
   {
     "id": 163483,
-    "name": "Rincon De Los Coroneles",
+    "name": "Rincon de los Coroneles",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -35976,7 +35976,7 @@
   },
   {
     "id": 163487,
-    "name": "Rincon De Tacuari",
+    "name": "Rincon de Tacuari",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36018,7 +36018,7 @@
   },
   {
     "id": 163489,
-    "name": "Paso De Las Yeguas",
+    "name": "Paso de las Yeguas",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36039,7 +36039,7 @@
   },
   {
     "id": 163490,
-    "name": "Minuano De Acegua",
+    "name": "Minuano de Acegua",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36081,7 +36081,7 @@
   },
   {
     "id": 163492,
-    "name": "Puntas De La Mina",
+    "name": "Puntas de la Mina",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36123,7 +36123,7 @@
   },
   {
     "id": 163494,
-    "name": "Cuchilla De Melo",
+    "name": "Cuchilla de Melo",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36144,7 +36144,7 @@
   },
   {
     "id": 163495,
-    "name": "Granja De Acegua",
+    "name": "Granja de Acegua",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36186,7 +36186,7 @@
   },
   {
     "id": 163497,
-    "name": "Sarandi De Acegua",
+    "name": "Sarandi de Acegua",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36207,7 +36207,7 @@
   },
   {
     "id": 163498,
-    "name": "Cruz De Piedra",
+    "name": "Cruz de Piedra",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36270,7 +36270,7 @@
   },
   {
     "id": 163501,
-    "name": "Puntas De Palleros",
+    "name": "Puntas de Palleros",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36291,7 +36291,7 @@
   },
   {
     "id": 163502,
-    "name": "Sauce De Conventos",
+    "name": "Sauce de Conventos",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36354,7 +36354,7 @@
   },
   {
     "id": 163505,
-    "name": "Paso De Las Tropas",
+    "name": "Paso de las Tropas",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36396,7 +36396,7 @@
   },
   {
     "id": 163507,
-    "name": "Chacras De Melo",
+    "name": "Chacras de Melo",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36522,7 +36522,7 @@
   },
   {
     "id": 163513,
-    "name": "Paso De La Cruz",
+    "name": "Paso de la Cruz",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36711,7 +36711,7 @@
   },
   {
     "id": 163522,
-    "name": "Rincon De La Urbana",
+    "name": "Rincon de la Urbana",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36732,7 +36732,7 @@
   },
   {
     "id": 163523,
-    "name": "Rincon De Suarez",
+    "name": "Rincon de Suarez",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36753,7 +36753,7 @@
   },
   {
     "id": 163524,
-    "name": "Paso De Los Carros",
+    "name": "Paso de los Carros",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36795,7 +36795,7 @@
   },
   {
     "id": 163526,
-    "name": "Rincon De Py",
+    "name": "Rincon de Py",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36837,7 +36837,7 @@
   },
   {
     "id": 163528,
-    "name": "Rincon De Contreras",
+    "name": "Rincon de Contreras",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36858,7 +36858,7 @@
   },
   {
     "id": 163529,
-    "name": "Puntas De Tacuari",
+    "name": "Puntas de Tacuari",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36900,7 +36900,7 @@
   },
   {
     "id": 163531,
-    "name": "Calera De Recalde",
+    "name": "Calera de Recalde",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -36942,7 +36942,7 @@
   },
   {
     "id": 163533,
-    "name": "Laguna Del Junco",
+    "name": "Laguna del Junco",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -37005,7 +37005,7 @@
   },
   {
     "id": 163536,
-    "name": "Costas De Tacuari",
+    "name": "Costas de Tacuari",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37026,7 +37026,7 @@
   },
   {
     "id": 163537,
-    "name": "Paso De Piriz",
+    "name": "Paso de Piriz",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37152,7 +37152,7 @@
   },
   {
     "id": 163543,
-    "name": "Cuchilla De Dionisio",
+    "name": "Cuchilla de Dionisio",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37173,7 +37173,7 @@
   },
   {
     "id": 163544,
-    "name": "Cerros De Amaro",
+    "name": "Cerros de Amaro",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37194,7 +37194,7 @@
   },
   {
     "id": 163545,
-    "name": "Puntas De Leoncho",
+    "name": "Puntas de Leoncho",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37215,7 +37215,7 @@
   },
   {
     "id": 163546,
-    "name": "Cuchilla De Olmos",
+    "name": "Cuchilla de Olmos",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37320,7 +37320,7 @@
   },
   {
     "id": 163551,
-    "name": "Puntas Del Oro",
+    "name": "Puntas del Oro",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37341,7 +37341,7 @@
   },
   {
     "id": 163552,
-    "name": "Puntas De Los Ceibos",
+    "name": "Puntas de los Ceibos",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37446,7 +37446,7 @@
   },
   {
     "id": 163557,
-    "name": "Paso De La Laguna",
+    "name": "Paso de la Laguna",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37488,7 +37488,7 @@
   },
   {
     "id": 163559,
-    "name": "Lechiguana De Corrales",
+    "name": "Lechiguana de Corrales",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37509,7 +37509,7 @@
   },
   {
     "id": 163560,
-    "name": "Arrayanes De Corral De Cebollati",
+    "name": "Arrayanes de Corral de Cebollati",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37530,7 +37530,7 @@
   },
   {
     "id": 163561,
-    "name": "Cañada De Las Piedras",
+    "name": "Cañada de las Piedras",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37551,7 +37551,7 @@
   },
   {
     "id": 163562,
-    "name": "Arrayanes De Cebollati",
+    "name": "Arrayanes de Cebollati",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37593,7 +37593,7 @@
   },
   {
     "id": 163564,
-    "name": "Paso Del Sauce",
+    "name": "Paso del Sauce",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37614,7 +37614,7 @@
   },
   {
     "id": 163565,
-    "name": "Puntas De Quebracho",
+    "name": "Puntas de Quebracho",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37656,7 +37656,7 @@
   },
   {
     "id": 163567,
-    "name": "Sierra Del Yerbal",
+    "name": "Sierra del Yerbal",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37698,7 +37698,7 @@
   },
   {
     "id": 163569,
-    "name": "Rincon De Iguini",
+    "name": "Rincon de Iguini",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37719,7 +37719,7 @@
   },
   {
     "id": 163570,
-    "name": "Rincon De Quintana",
+    "name": "Rincon de Quintana",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37782,7 +37782,7 @@
   },
   {
     "id": 163573,
-    "name": "Rincon De Los Francos",
+    "name": "Rincon de los Francos",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37845,7 +37845,7 @@
   },
   {
     "id": 163576,
-    "name": "Costas Del Arroyo Malo",
+    "name": "Costas del Arroyo Malo",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37887,7 +37887,7 @@
   },
   {
     "id": 163578,
-    "name": "Molles De Olimar",
+    "name": "Molles de Olimar",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37908,7 +37908,7 @@
   },
   {
     "id": 163579,
-    "name": "Corrales De Cebollati",
+    "name": "Corrales de Cebollati",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37929,7 +37929,7 @@
   },
   {
     "id": 163580,
-    "name": "Sauce De Corrales",
+    "name": "Sauce de Corrales",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -37992,7 +37992,7 @@
   },
   {
     "id": 163583,
-    "name": "Rincon De Gadea",
+    "name": "Rincon de Gadea",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -38013,7 +38013,7 @@
   },
   {
     "id": 163584,
-    "name": "Paso De La Atahona",
+    "name": "Paso de la Atahona",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -38034,7 +38034,7 @@
   },
   {
     "id": 163585,
-    "name": "Rincon De Urtubey",
+    "name": "Rincon de Urtubey",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -38055,7 +38055,7 @@
   },
   {
     "id": 163586,
-    "name": "Paso De Averias",
+    "name": "Paso de Averias",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -38076,7 +38076,7 @@
   },
   {
     "id": 163587,
-    "name": "Noques De Olimar Chico",
+    "name": "Noques de Olimar Chico",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -38139,7 +38139,7 @@
   },
   {
     "id": 163590,
-    "name": "Paso Del Ombu",
+    "name": "Paso del Ombu",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38160,7 +38160,7 @@
   },
   {
     "id": 163591,
-    "name": "La Fortaleza De Santa Teresa",
+    "name": "La Fortaleza de Santa Teresa",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38202,7 +38202,7 @@
   },
   {
     "id": 163593,
-    "name": "Paso De Lopez",
+    "name": "Paso de Lopez",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38223,7 +38223,7 @@
   },
   {
     "id": 163594,
-    "name": "Cerro De Los Rocha",
+    "name": "Cerro de los Rocha",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38265,7 +38265,7 @@
   },
   {
     "id": 163596,
-    "name": "Vuelta Del Palmar",
+    "name": "Vuelta del Palmar",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38307,7 +38307,7 @@
   },
   {
     "id": 163598,
-    "name": "Palmar De Castillos",
+    "name": "Palmar de Castillos",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38328,7 +38328,7 @@
   },
   {
     "id": 163599,
-    "name": "Rincon De Los Olivera",
+    "name": "Rincon de los Olivera",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38349,7 +38349,7 @@
   },
   {
     "id": 163600,
-    "name": "Cerro De Pescadores",
+    "name": "Cerro de Pescadores",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38370,7 +38370,7 @@
   },
   {
     "id": 163601,
-    "name": "Rincon De Valizas",
+    "name": "Rincon de Valizas",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38454,7 +38454,7 @@
   },
   {
     "id": 163605,
-    "name": "Abra De Alferez",
+    "name": "Abra de Alferez",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38559,7 +38559,7 @@
   },
   {
     "id": 163610,
-    "name": "Empalme De Velazquez",
+    "name": "Empalme de Velazquez",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38622,7 +38622,7 @@
   },
   {
     "id": 163613,
-    "name": "Sarandi De La India Muerta",
+    "name": "Sarandi de la India Muerta",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38643,7 +38643,7 @@
   },
   {
     "id": 163614,
-    "name": "Puntas De Don Carlos",
+    "name": "Puntas de Don Carlos",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38748,7 +38748,7 @@
   },
   {
     "id": 163619,
-    "name": "Cuchilla Del Arbolito",
+    "name": "Cuchilla del Arbolito",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38811,7 +38811,7 @@
   },
   {
     "id": 163622,
-    "name": "Sierra De Los Rocha",
+    "name": "Sierra de los Rocha",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38874,7 +38874,7 @@
   },
   {
     "id": 163625,
-    "name": "Sauce De Rocha",
+    "name": "Sauce de Rocha",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -38958,7 +38958,7 @@
   },
   {
     "id": 163629,
-    "name": "Cuchilla De Garzon",
+    "name": "Cuchilla de Garzon",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -39000,7 +39000,7 @@
   },
   {
     "id": 163631,
-    "name": "Rincon De Aparicio",
+    "name": "Rincon de Aparicio",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39042,7 +39042,7 @@
   },
   {
     "id": 163633,
-    "name": "Sarandi De Aigua",
+    "name": "Sarandi de Aigua",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39063,7 +39063,7 @@
   },
   {
     "id": 163634,
-    "name": "Paso De Los Talas",
+    "name": "Paso de los Talas",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39084,7 +39084,7 @@
   },
   {
     "id": 163635,
-    "name": "Puntas De Jose Ignacio",
+    "name": "Puntas de Jose Ignacio",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39105,7 +39105,7 @@
   },
   {
     "id": 163636,
-    "name": "Paso De La Cantera",
+    "name": "Paso de la Cantera",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39126,7 +39126,7 @@
   },
   {
     "id": 163637,
-    "name": "Molles De Garzon",
+    "name": "Molles de Garzon",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39147,7 +39147,7 @@
   },
   {
     "id": 163638,
-    "name": "Costas De Jose Ignacio",
+    "name": "Costas de Jose Ignacio",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39168,7 +39168,7 @@
   },
   {
     "id": 163639,
-    "name": "Sauce De Aigua",
+    "name": "Sauce de Aigua",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39210,7 +39210,7 @@
   },
   {
     "id": 163641,
-    "name": "Puntas Del Campanera",
+    "name": "Puntas del Campanera",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39294,7 +39294,7 @@
   },
   {
     "id": 163645,
-    "name": "Zanja Del Tigre",
+    "name": "Zanja del Tigre",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39315,7 +39315,7 @@
   },
   {
     "id": 163646,
-    "name": "Arroyito De Medina",
+    "name": "Arroyito de Medina",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39399,7 +39399,7 @@
   },
   {
     "id": 163650,
-    "name": "Abra De Perdomo",
+    "name": "Abra de Perdomo",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39504,7 +39504,7 @@
   },
   {
     "id": 163655,
-    "name": "Laguna Del Sauce",
+    "name": "Laguna del Sauce",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39525,7 +39525,7 @@
   },
   {
     "id": 163656,
-    "name": "Corte De La Leña",
+    "name": "Corte de la Leña",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39546,7 +39546,7 @@
   },
   {
     "id": 163657,
-    "name": "Pago De La Paja",
+    "name": "Pago de la Paja",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39567,7 +39567,7 @@
   },
   {
     "id": 163658,
-    "name": "Rincon De Los Sosa",
+    "name": "Rincon de los Sosa",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39588,7 +39588,7 @@
   },
   {
     "id": 163659,
-    "name": "San Juan Del Este",
+    "name": "San Juan del Este",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39651,7 +39651,7 @@
   },
   {
     "id": 163662,
-    "name": "Puntas De Mataojo",
+    "name": "Puntas de Mataojo",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39672,7 +39672,7 @@
   },
   {
     "id": 163663,
-    "name": "Puntas De Pan De Azucar",
+    "name": "Puntas de Pan de Azucar",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39693,7 +39693,7 @@
   },
   {
     "id": 163664,
-    "name": "Abra De Castellanos",
+    "name": "Abra de Castellanos",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39735,7 +39735,7 @@
   },
   {
     "id": 163666,
-    "name": "Puntas De La Sierra",
+    "name": "Puntas de la Sierra",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39756,7 +39756,7 @@
   },
   {
     "id": 163667,
-    "name": "Lago De Los Cisnes",
+    "name": "Lago de los Cisnes",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39777,7 +39777,7 @@
   },
   {
     "id": 163668,
-    "name": "Barra Del Sauce",
+    "name": "Barra del Sauce",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -39840,7 +39840,7 @@
   },
   {
     "id": 163671,
-    "name": "Costas De Santa Lucia",
+    "name": "Costas de Santa Lucia",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -39861,7 +39861,7 @@
   },
   {
     "id": 163672,
-    "name": "Paso Rivero De Vejigas",
+    "name": "Paso Rivero de Vejigas",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -39966,7 +39966,7 @@
   },
   {
     "id": 163677,
-    "name": "Puntas De Vejigas",
+    "name": "Puntas de Vejigas",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40008,7 +40008,7 @@
   },
   {
     "id": 163679,
-    "name": "Costas De Pedernal",
+    "name": "Costas de Pedernal",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40071,7 +40071,7 @@
   },
   {
     "id": 163682,
-    "name": "Sarandi De Migues",
+    "name": "Sarandi de Migues",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40092,7 +40092,7 @@
   },
   {
     "id": 163683,
-    "name": "Sauce Solo De Montes",
+    "name": "Sauce Solo de Montes",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40113,7 +40113,7 @@
   },
   {
     "id": 163684,
-    "name": "Sauce Solo De Migues",
+    "name": "Sauce Solo de Migues",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40155,7 +40155,7 @@
   },
   {
     "id": 163686,
-    "name": "Solis Chico De Migues",
+    "name": "Solis Chico de Migues",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40176,7 +40176,7 @@
   },
   {
     "id": 163687,
-    "name": "Puntas Del Arenal",
+    "name": "Puntas del Arenal",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40197,7 +40197,7 @@
   },
   {
     "id": 163688,
-    "name": "El Colorado De Migues",
+    "name": "El Colorado de Migues",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40239,7 +40239,7 @@
   },
   {
     "id": 163690,
-    "name": "Costas De Solis",
+    "name": "Costas de Solis",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40281,7 +40281,7 @@
   },
   {
     "id": 163692,
-    "name": "Cuchilla De Zeballos",
+    "name": "Cuchilla de Zeballos",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40302,7 +40302,7 @@
   },
   {
     "id": 163693,
-    "name": "Puntas De Pedrera",
+    "name": "Puntas de Pedrera",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40344,7 +40344,7 @@
   },
   {
     "id": 163695,
-    "name": "Cuchilla Cabo De Hornos",
+    "name": "Cuchilla Cabo de Hornos",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40365,7 +40365,7 @@
   },
   {
     "id": 163696,
-    "name": "Sauce De Solis",
+    "name": "Sauce de Solis",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40407,7 +40407,7 @@
   },
   {
     "id": 163698,
-    "name": "Cueva Del Tigre",
+    "name": "Cueva del Tigre",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40512,7 +40512,7 @@
   },
   {
     "id": 163703,
-    "name": "Costas Del Colorado",
+    "name": "Costas del Colorado",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40533,7 +40533,7 @@
   },
   {
     "id": 163704,
-    "name": "Costas Del Colorado Este",
+    "name": "Costas del Colorado Este",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40554,7 +40554,7 @@
   },
   {
     "id": 163705,
-    "name": "Rincon Del Conde",
+    "name": "Rincon del Conde",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40575,7 +40575,7 @@
   },
   {
     "id": 163706,
-    "name": "Costa Del Tala Norte",
+    "name": "Costa del Tala Norte",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40596,7 +40596,7 @@
   },
   {
     "id": 163707,
-    "name": "Paso De La Salamanca",
+    "name": "Paso de la Salamanca",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40617,7 +40617,7 @@
   },
   {
     "id": 163708,
-    "name": "Vejigas De Tala",
+    "name": "Vejigas de Tala",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40659,7 +40659,7 @@
   },
   {
     "id": 163710,
-    "name": "Costas Del Tala",
+    "name": "Costas del Tala",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40680,7 +40680,7 @@
   },
   {
     "id": 163711,
-    "name": "Puntas De Las Violetas",
+    "name": "Puntas de las Violetas",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40701,7 +40701,7 @@
   },
   {
     "id": 163712,
-    "name": "Barra Del Tala",
+    "name": "Barra del Tala",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40722,7 +40722,7 @@
   },
   {
     "id": 163713,
-    "name": "Costa Del Tala Este",
+    "name": "Costa del Tala Este",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40743,7 +40743,7 @@
   },
   {
     "id": 163714,
-    "name": "Paso De Los Difuntos",
+    "name": "Paso de los Difuntos",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40785,7 +40785,7 @@
   },
   {
     "id": 163716,
-    "name": "Paso De La Paloma",
+    "name": "Paso de la Paloma",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40806,7 +40806,7 @@
   },
   {
     "id": 163717,
-    "name": "Puntas De Pantanoso Este",
+    "name": "Puntas de Pantanoso Este",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40827,7 +40827,7 @@
   },
   {
     "id": 163718,
-    "name": "Costa De Pando San Bautista",
+    "name": "Costa de Pando San Bautista",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40848,7 +40848,7 @@
   },
   {
     "id": 163719,
-    "name": "Puntas De Cochengo",
+    "name": "Puntas de Cochengo",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40953,7 +40953,7 @@
   },
   {
     "id": 163724,
-    "name": "Puntas De Pantanoso",
+    "name": "Puntas de Pantanoso",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -40995,7 +40995,7 @@
   },
   {
     "id": 163726,
-    "name": "Paso De Cuello",
+    "name": "Paso de Cuello",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41016,7 +41016,7 @@
   },
   {
     "id": 163727,
-    "name": "Cuchilla De Machin",
+    "name": "Cuchilla de Machin",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41037,7 +41037,7 @@
   },
   {
     "id": 163728,
-    "name": "Puntas De Cañada Cardozo",
+    "name": "Puntas de Cañada Cardozo",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41079,7 +41079,7 @@
   },
   {
     "id": 163730,
-    "name": "Puntas De Mata Siete",
+    "name": "Puntas de Mata Siete",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41163,7 +41163,7 @@
   },
   {
     "id": 163734,
-    "name": "Rancherios De Ponce",
+    "name": "Rancherios de Ponce",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41184,7 +41184,7 @@
   },
   {
     "id": 163735,
-    "name": "Barrio Del Libertador",
+    "name": "Barrio del Libertador",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41205,7 +41205,7 @@
   },
   {
     "id": 163736,
-    "name": "Costa Del Sauce",
+    "name": "Costa del Sauce",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41226,7 +41226,7 @@
   },
   {
     "id": 163737,
-    "name": "Cuchilla De Rocha",
+    "name": "Cuchilla de Rocha",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41247,7 +41247,7 @@
   },
   {
     "id": 163738,
-    "name": "Pantanoso Del Sauce",
+    "name": "Pantanoso del Sauce",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41289,7 +41289,7 @@
   },
   {
     "id": 163740,
-    "name": "Costa De Pando",
+    "name": "Costa de Pando",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41310,7 +41310,7 @@
   },
   {
     "id": 163741,
-    "name": "Barra De La Pedrera",
+    "name": "Barra de la Pedrera",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41373,7 +41373,7 @@
   },
   {
     "id": 163744,
-    "name": "Puntas De Canelon Chico",
+    "name": "Puntas de Canelon Chico",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41394,7 +41394,7 @@
   },
   {
     "id": 163745,
-    "name": "Carrasco Del Sauce",
+    "name": "Carrasco del Sauce",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41436,7 +41436,7 @@
   },
   {
     "id": 163747,
-    "name": "Piedritas De Suarez",
+    "name": "Piedritas de Suarez",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41457,7 +41457,7 @@
   },
   {
     "id": 163748,
-    "name": "Puntas De Cañada Grande",
+    "name": "Puntas de Cañada Grande",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41478,7 +41478,7 @@
   },
   {
     "id": 163749,
-    "name": "Rincon De Pando",
+    "name": "Rincon de Pando",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41520,7 +41520,7 @@
   },
   {
     "id": 163751,
-    "name": "Villa Prados De Toledo",
+    "name": "Villa Prados de Toledo",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41541,7 +41541,7 @@
   },
   {
     "id": 163752,
-    "name": "Medanos De Solymar",
+    "name": "Medanos de Solymar",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41562,7 +41562,7 @@
   },
   {
     "id": 163753,
-    "name": "Paso Del Sordo",
+    "name": "Paso del Sordo",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41583,7 +41583,7 @@
   },
   {
     "id": 163754,
-    "name": "Rincon De Vidal",
+    "name": "Rincon de Vidal",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41604,7 +41604,7 @@
   },
   {
     "id": 163755,
-    "name": "Rincon De Velazquez",
+    "name": "Rincon de Velazquez",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41646,7 +41646,7 @@
   },
   {
     "id": 163757,
-    "name": "Paso De Los Francos",
+    "name": "Paso de los Francos",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41667,7 +41667,7 @@
   },
   {
     "id": 163758,
-    "name": "Paso De Los Alamos",
+    "name": "Paso de los Alamos",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41751,7 +41751,7 @@
   },
   {
     "id": 163762,
-    "name": "Canelon Grande De Pacheco",
+    "name": "Canelon Grande de Pacheco",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41772,7 +41772,7 @@
   },
   {
     "id": 163763,
-    "name": "Camino De La Cadena",
+    "name": "Camino de la Cadena",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41877,7 +41877,7 @@
   },
   {
     "id": 163768,
-    "name": "Villa Los Alpes",
+    "name": "Villa los Alpes",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41961,7 +41961,7 @@
   },
   {
     "id": 163772,
-    "name": "Rincon Del Gigante",
+    "name": "Rincon del Gigante",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -41982,7 +41982,7 @@
   },
   {
     "id": 163773,
-    "name": "Puntas De Brujas",
+    "name": "Puntas de Brujas",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -42129,7 +42129,7 @@
   },
   {
     "id": 163780,
-    "name": "Paso Del Bote",
+    "name": "Paso del Bote",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -42171,7 +42171,7 @@
   },
   {
     "id": 163782,
-    "name": "Puente De Brujas",
+    "name": "Puente de Brujas",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -42192,7 +42192,7 @@
   },
   {
     "id": 163783,
-    "name": "Canelon Chico De Progreso",
+    "name": "Canelon Chico de Progreso",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -42234,7 +42234,7 @@
   },
   {
     "id": 163785,
-    "name": "Colorado Y Brujas",
+    "name": "Colorado y Brujas",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -42276,7 +42276,7 @@
   },
   {
     "id": 163787,
-    "name": "Rincon De Portezuelo",
+    "name": "Rincon de Portezuelo",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -42339,7 +42339,7 @@
   },
   {
     "id": 163790,
-    "name": "Paso Del Colorado",
+    "name": "Paso del Colorado",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -42360,7 +42360,7 @@
   },
   {
     "id": 163791,
-    "name": "Rincon Del Colorado",
+    "name": "Rincon del Colorado",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -42402,7 +42402,7 @@
   },
   {
     "id": 163793,
-    "name": "Cuchilla De Sierra",
+    "name": "Cuchilla de Sierra",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -42486,7 +42486,7 @@
   },
   {
     "id": 163797,
-    "name": "Chacras De Paysandu Sur",
+    "name": "Chacras de Paysandu Sur",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -42507,7 +42507,7 @@
   },
   {
     "id": 163798,
-    "name": "Chacras De Paysandu Norte",
+    "name": "Chacras de Paysandu Norte",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -42612,7 +42612,7 @@
   },
   {
     "id": 163803,
-    "name": "Costas Del Sarandi",
+    "name": "Costas del Sarandi",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -42633,7 +42633,7 @@
   },
   {
     "id": 163804,
-    "name": "Al Sur De Arroyo Sacra",
+    "name": "Al Sur de Arroyo Sacra",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -42675,7 +42675,7 @@
   },
   {
     "id": 163806,
-    "name": "Ciudad Del Plata",
+    "name": "Ciudad del Plata",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -42696,7 +42696,7 @@
   },
   {
     "id": 163807,
-    "name": "Rincon De La Bolsa",
+    "name": "Rincon de la Bolsa",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -42801,7 +42801,7 @@
   },
   {
     "id": 163812,
-    "name": "Sauce Solo Del Rio Negro",
+    "name": "Sauce Solo del Rio Negro",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -42990,7 +42990,7 @@
   },
   {
     "id": 163821,
-    "name": "Costas De Caraguata",
+    "name": "Costas de Caraguata",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -43116,7 +43116,7 @@
   },
   {
     "id": 163827,
-    "name": "Barrio Los Panoramas",
+    "name": "Barrio los Panoramas",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -43221,7 +43221,7 @@
   },
   {
     "id": 163832,
-    "name": "Lomas De Toledo",
+    "name": "Lomas de Toledo",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -43347,7 +43347,7 @@
   },
   {
     "id": 163838,
-    "name": "Villa Huertos De Toledo",
+    "name": "Villa Huertos de Toledo",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -43431,7 +43431,7 @@
   },
   {
     "id": 163842,
-    "name": "Colonia Osimani Y Llerena",
+    "name": "Colonia Osimani y Llerena",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -43452,7 +43452,7 @@
   },
   {
     "id": 163843,
-    "name": "Barrio La Matutina",
+    "name": "Barrio la Matutina",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -43515,7 +43515,7 @@
   },
   {
     "id": 163846,
-    "name": "Bañado De Cañas",
+    "name": "Bañado de Cañas",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -43536,7 +43536,7 @@
   },
   {
     "id": 163847,
-    "name": "Bañado De Las Pajas",
+    "name": "Bañado de las Pajas",
     "state_id": 3211,
     "state_code": "CL",
     "country_id": 235,
@@ -43557,7 +43557,7 @@
   },
   {
     "id": 163848,
-    "name": "Bañado Del Chaja",
+    "name": "Bañado del Chaja",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -43578,7 +43578,7 @@
   },
   {
     "id": 163849,
-    "name": "Bañado De Oro",
+    "name": "Bañado de Oro",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -43725,7 +43725,7 @@
   },
   {
     "id": 163856,
-    "name": "Cañada De La Cruz",
+    "name": "Cañada de la Cruz",
     "state_id": 3206,
     "state_code": "MA",
     "country_id": 235,
@@ -43746,7 +43746,7 @@
   },
   {
     "id": 163857,
-    "name": "Cañada Del Estado",
+    "name": "Cañada del Estado",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -43767,7 +43767,7 @@
   },
   {
     "id": 163858,
-    "name": "Cañada Del Sauce",
+    "name": "Cañada del Sauce",
     "state_id": 3214,
     "state_code": "TT",
     "country_id": 235,
@@ -43788,7 +43788,7 @@
   },
   {
     "id": 163859,
-    "name": "Cañada De Montaño",
+    "name": "Cañada de Montaño",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -43914,7 +43914,7 @@
   },
   {
     "id": 163865,
-    "name": "Cerro Blanco De Cuñapiru",
+    "name": "Cerro Blanco de Cuñapiru",
     "state_id": 3207,
     "state_code": "RV",
     "country_id": 235,
@@ -43956,7 +43956,7 @@
   },
   {
     "id": 163867,
-    "name": "Consejo Del Niño",
+    "name": "Consejo del Niño",
     "state_id": 3215,
     "state_code": "LA",
     "country_id": 235,
@@ -44040,7 +44040,7 @@
   },
   {
     "id": 163871,
-    "name": "Isla De Arguelles",
+    "name": "Isla de Arguelles",
     "state_id": 3210,
     "state_code": "RN",
     "country_id": 235,
@@ -44082,7 +44082,7 @@
   },
   {
     "id": 163873,
-    "name": "Paso Del Bañado",
+    "name": "Paso del Bañado",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -44166,7 +44166,7 @@
   },
   {
     "id": 163877,
-    "name": "Puntas De Cañada Grande",
+    "name": "Puntas de Cañada Grande",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -44187,7 +44187,7 @@
   },
   {
     "id": 163878,
-    "name": "San Jose De Las Cañas",
+    "name": "San Jose de las Cañas",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -44229,7 +44229,7 @@
   },
   {
     "id": 163880,
-    "name": "Lomas De Carmelo",
+    "name": "Lomas de Carmelo",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -44313,7 +44313,7 @@
   },
   {
     "id": 163884,
-    "name": "Palmar De Porrua",
+    "name": "Palmar de Porrua",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -44460,7 +44460,7 @@
   },
   {
     "id": 163891,
-    "name": "Colonia Las Delicias",
+    "name": "Colonia las Delicias",
     "state_id": 3212,
     "state_code": "PA",
     "country_id": 235,
@@ -44544,7 +44544,7 @@
   },
   {
     "id": 163895,
-    "name": "Azotea De Vera",
+    "name": "Azotea de Vera",
     "state_id": 3219,
     "state_code": "SO",
     "country_id": 235,
@@ -44586,7 +44586,7 @@
   },
   {
     "id": 163897,
-    "name": "Cuchilla Del Salto",
+    "name": "Cuchilla del Salto",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -44649,7 +44649,7 @@
   },
   {
     "id": 163900,
-    "name": "Colonia Treinta Y Tres Orientales",
+    "name": "Colonia Treinta y Tres Orientales",
     "state_id": 3217,
     "state_code": "FD",
     "country_id": 235,
@@ -44712,7 +44712,7 @@
   },
   {
     "id": 163903,
-    "name": "Cuchilla De Pereira",
+    "name": "Cuchilla de Pereira",
     "state_id": 3204,
     "state_code": "SJ",
     "country_id": 235,
@@ -44817,7 +44817,7 @@
   },
   {
     "id": 163908,
-    "name": "Capilla De Cella",
+    "name": "Capilla de Cella",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -44859,7 +44859,7 @@
   },
   {
     "id": 163910,
-    "name": "Paso De Las Toscas",
+    "name": "Paso de las Toscas",
     "state_id": 3221,
     "state_code": "TA",
     "country_id": 235,
@@ -44880,7 +44880,7 @@
   },
   {
     "id": 163911,
-    "name": "Fortin De San Miguel",
+    "name": "Fortin de San Miguel",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -44901,7 +44901,7 @@
   },
   {
     "id": 163912,
-    "name": "Puntas De Toledo",
+    "name": "Puntas de Toledo",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -44985,7 +44985,7 @@
   },
   {
     "id": 163916,
-    "name": "Rincon De Cuadra",
+    "name": "Rincon de Cuadra",
     "state_id": 3209,
     "state_code": "DU",
     "country_id": 235,
@@ -45027,7 +45027,7 @@
   },
   {
     "id": 163918,
-    "name": "Rincon De Carrasco",
+    "name": "Rincon de Carrasco",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -45048,7 +45048,7 @@
   },
   {
     "id": 163919,
-    "name": "Paso Del Medio",
+    "name": "Paso del Medio",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -45090,7 +45090,7 @@
   },
   {
     "id": 163921,
-    "name": "Costa Del Pantanoso",
+    "name": "Costa del Pantanoso",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -45321,7 +45321,7 @@
   },
   {
     "id": 163932,
-    "name": "Puntas Del Rosario",
+    "name": "Puntas del Rosario",
     "state_id": 3208,
     "state_code": "CO",
     "country_id": 235,
@@ -45363,7 +45363,7 @@
   },
   {
     "id": 163934,
-    "name": "Cuchilla Alta Y El Galeon",
+    "name": "Cuchilla Alta y el Galeon",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -45447,7 +45447,7 @@
   },
   {
     "id": 163938,
-    "name": "Chacras De Belen",
+    "name": "Chacras de Belen",
     "state_id": 3220,
     "state_code": "SA",
     "country_id": 235,
@@ -45489,7 +45489,7 @@
   },
   {
     "id": 163940,
-    "name": "El Bosque De Lagomar",
+    "name": "El Bosque de Lagomar",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -45510,7 +45510,7 @@
   },
   {
     "id": 163941,
-    "name": "Vina Del Mar",
+    "name": "Vina del Mar",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -45573,7 +45573,7 @@
   },
   {
     "id": 163944,
-    "name": "Monaco De Carrasco",
+    "name": "Monaco de Carrasco",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -45636,7 +45636,7 @@
   },
   {
     "id": 163947,
-    "name": "Villa Crespo Y San Andres",
+    "name": "Villa Crespo y San Andres",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -45678,7 +45678,7 @@
   },
   {
     "id": 163949,
-    "name": "Mar Del Plata",
+    "name": "Mar del Plata",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -45741,7 +45741,7 @@
   },
   {
     "id": 163952,
-    "name": "Diamante De La Pedrera",
+    "name": "Diamante de la Pedrera",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -45762,7 +45762,7 @@
   },
   {
     "id": 163953,
-    "name": "Barrancas De La Pedrera",
+    "name": "Barrancas de la Pedrera",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -45804,7 +45804,7 @@
   },
   {
     "id": 163955,
-    "name": "Santa Isabel De La Pedrera",
+    "name": "Santa Isabel de la Pedrera",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -45846,7 +45846,7 @@
   },
   {
     "id": 163957,
-    "name": "Mirador De La Tahona",
+    "name": "Mirador de la Tahona",
     "state_id": 3213,
     "state_code": "CA",
     "country_id": 235,
@@ -45888,7 +45888,7 @@
   },
   {
     "id": 163959,
-    "name": "Santa Teresa De La Coronilla 2",
+    "name": "Santa Teresa de la Coronilla 2",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -45909,7 +45909,7 @@
   },
   {
     "id": 163960,
-    "name": "Santa Teresa De La Coronilla 1",
+    "name": "Santa Teresa de la Coronilla 1",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,
@@ -45930,7 +45930,7 @@
   },
   {
     "id": 163961,
-    "name": "Coronilla Del Mar",
+    "name": "Coronilla del Mar",
     "state_id": 3216,
     "state_code": "RO",
     "country_id": 235,


### PR DESCRIPTION
## Summary

Uruguay city `name` values were imported title-cased, capitalising every token (e.g. `Paso De Los Toros`). This lowercases interior Spanish prepositions/articles per standard toponymy convention.

**651 of 2,010 rows** updated. Examples:
- `Paso De Los Toros` → `Paso de los Toros`
- `18 De Julio` → `18 de Julio`
- `Ciudad De La Costa` → `Ciudad de la Costa`
- `Rossell Y Rius` → `Rossell y Rius`

## Rules (see `bin/scripts/fixes/normalize_uy_prepositions.py`)

- Lowercases only `de`, `del`, `la`, `las`, `los`, `el`, `y` when **interior** to the name.
- **First-word** connectors preserved (`La Floresta` stays `La Floresta`).
- **Post-separator** connectors preserved — `San Rafael - El Placer` and `Pinares - Las Delicias` are left unchanged (the segment after `-` is its own name).
- **`A` excluded** to protect middle initials (`Capitan J A Artigas`); the one true preposition case (`Palo A Pique` → `Palo a Pique`) is handled explicitly.
- Only `name` changes — `native` is null for these rows; no FKs/coords touched. Idempotent (re-run = 0 changes).

## Reviewer note

Prepositions (`de`/`del`, ~623 of the changes) are unambiguous. Interior **articles** after a generic word — e.g. `Estacion La Floresta` → `Estacion la Floresta`, `Villa El Tato` → `Villa el Tato` — follow the RAE lowercase rule but are mildly debatable since those are themselves place names. Flagging in case you'd prefer to keep articles capitalised in those ~30 cases.

## Test plan

- [ ] Spot-check a sample of renamed rows
- [ ] Confirm hyphenated names (`San Rafael - El Placer`) unchanged