### PR TITLE
fix(ci): cap sibling validator outputs + complete cities schema

### DIFF
--- a/.github/scripts/detect-duplicates.js
+++ b/.github/scripts/detect-duplicates.js
@@ -144,7 +144,11 @@ async function run() {
     }
   }
 
-  core.setOutput('warnings', JSON.stringify(warnings));
+  // Cap the emitted list — it is passed to the report step via an environment
+  // variable with a hard size limit, and dense localities can produce
+  // thousands of fuzzy-match warnings. Emit the true total separately.
+  core.setOutput('warnings', JSON.stringify(warnings.slice(0, 50)));
+  core.setOutput('warning_count', warnings.length.toString());
   core.setOutput('checked', checked.toString());
 
   core.info(`Duplicate check: ${checked} records checked, ${warnings.length} potential duplicates`);

--- a/.github/scripts/utils.js
+++ b/.github/scripts/utils.js
@@ -15,7 +15,7 @@ const AUTO_MANAGED_FIELDS = ['id', 'created_at', 'updated_at', 'flag'];
 const SCHEMA = {
   cities: {
     required: ['name', 'state_id', 'state_code', 'country_id', 'country_code', 'latitude', 'longitude'],
-    optional: ['state_name', 'country_name', 'wikiDataId', 'timezone'],
+    optional: ['state_name', 'country_name', 'wikiDataId', 'timezone', 'native', 'type', 'level', 'parent_id', 'population', 'translations'],
     rules: {
       name: { type: 'string', maxLength: 255, nonEmpty: true },
       state_id: { type: 'integer', positive: true },

--- a/.github/scripts/validate-coordinates.js
+++ b/.github/scripts/validate-coordinates.js
@@ -35,6 +35,7 @@ async function run() {
   } else {
     core.warning('country-bounds.json not found. Skipping coordinate bounds check.');
     core.setOutput('warnings', JSON.stringify([]));
+    core.setOutput('warning_count', '0');
     core.setOutput('checked', '0');
     return;
   }
@@ -103,7 +104,10 @@ async function run() {
     }
   }
 
-  core.setOutput('warnings', JSON.stringify(warnings));
+  // Cap the emitted list (env-var size limit in the report step); emit the
+  // true total separately.
+  core.setOutput('warnings', JSON.stringify(warnings.slice(0, 50)));
+  core.setOutput('warning_count', warnings.length.toString());
   core.setOutput('checked', checked.toString());
 
   core.info(`Coordinate bounds: ${checked} checked, ${warnings.length} warnings`);

--- a/.github/scripts/validate-cross-reference.js
+++ b/.github/scripts/validate-cross-reference.js
@@ -48,6 +48,7 @@ async function run() {
   if (!countries) {
     core.warning('Could not load countries.json for cross-reference. Skipping.');
     core.setOutput('errors', JSON.stringify([]));
+    core.setOutput('error_count', '0');
     core.setOutput('valid', '0');
     core.setOutput('has_errors', 'false');
     return;
@@ -250,7 +251,10 @@ async function run() {
     }
   }
 
-  core.setOutput('errors', JSON.stringify(errors));
+  // Cap the emitted list (env-var size limit in the report step); emit the
+  // true total separately. has_errors reflects the full count.
+  core.setOutput('errors', JSON.stringify(errors.slice(0, 50)));
+  core.setOutput('error_count', errors.length.toString());
   core.setOutput('valid', validCount.toString());
   core.setOutput('has_errors', (errors.length > 0).toString());
 

--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -122,11 +122,14 @@ jobs:
           SCHEMA_RECORD_COUNT: ${{ steps.schema.outputs.record_count }}
           SCHEMA_HAS_ERRORS: ${{ steps.schema.outputs.has_errors }}
           CROSSREF_ERRORS: ${{ steps.crossref.outputs.errors }}
+          CROSSREF_ERROR_COUNT: ${{ steps.crossref.outputs.error_count }}
           CROSSREF_VALID: ${{ steps.crossref.outputs.valid }}
           CROSSREF_HAS_ERRORS: ${{ steps.crossref.outputs.has_errors }}
           COORD_WARNINGS: ${{ steps.coords.outputs.warnings }}
+          COORD_WARNING_COUNT: ${{ steps.coords.outputs.warning_count }}
           COORD_CHECKED: ${{ steps.coords.outputs.checked }}
           DUP_WARNINGS: ${{ steps.duplicates.outputs.warnings }}
+          DUP_WARNING_COUNT: ${{ steps.duplicates.outputs.warning_count }}
           DUP_CHECKED: ${{ steps.duplicates.outputs.checked }}
           URL_ERRORS: ${{ steps.urls.outputs.errors }}
           URL_VALID: ${{ steps.urls.outputs.valid }}
@@ -146,11 +149,14 @@ jobs:
             const schemaRecordCount = parseInt(process.env.SCHEMA_RECORD_COUNT || '0');
             const schemaHasErrors = process.env.SCHEMA_HAS_ERRORS === 'true';
             const crossrefErrors = JSON.parse(process.env.CROSSREF_ERRORS || '[]');
+            const crossrefErrorCount = parseInt(process.env.CROSSREF_ERROR_COUNT || String(crossrefErrors.length));
             const crossrefValid = parseInt(process.env.CROSSREF_VALID || '0');
             const crossrefHasErrors = process.env.CROSSREF_HAS_ERRORS === 'true';
             const coordWarnings = JSON.parse(process.env.COORD_WARNINGS || '[]');
+            const coordWarningCount = parseInt(process.env.COORD_WARNING_COUNT || String(coordWarnings.length));
             const coordChecked = parseInt(process.env.COORD_CHECKED || '0');
             const dupWarnings = JSON.parse(process.env.DUP_WARNINGS || '[]');
+            const dupWarningCount = parseInt(process.env.DUP_WARNING_COUNT || String(dupWarnings.length));
             const dupChecked = parseInt(process.env.DUP_CHECKED || '0');
             const urlErrors = JSON.parse(process.env.URL_ERRORS || '[]');
             const urlValid = parseInt(process.env.URL_VALID || '0');
@@ -219,7 +225,7 @@ jobs:
             report += '\n';
 
             // Cross-Reference
-            if (crossrefValid > 0 || crossrefErrors.length > 0) {
+            if (crossrefValid > 0 || crossrefErrorCount > 0) {
               report += '### Cross-Reference Validation\n';
               if (crossrefValid > 0) {
                 report += `:white_check_mark: ${crossrefValid} reference(s) verified\n`;
@@ -227,15 +233,21 @@ jobs:
               for (const err of crossrefErrors.slice(0, 10)) {
                 report += `- :x: ${err}\n`;
               }
+              if (crossrefErrorCount > 10) {
+                report += `- _...and ${crossrefErrorCount - 10} more errors_\n`;
+              }
               report += '\n';
             }
 
             // Coordinate Bounds
-            if (coordChecked > 0 || coordWarnings.length > 0) {
+            if (coordChecked > 0 || coordWarningCount > 0) {
               report += '### Geo-Bounds Check\n';
-              if (coordWarnings.length > 0) {
+              if (coordWarningCount > 0) {
                 for (const warn of coordWarnings.slice(0, 10)) {
                   report += `- :warning: ${warn}\n`;
+                }
+                if (coordWarningCount > 10) {
+                  report += `- _...and ${coordWarningCount - 10} more warnings_\n`;
                 }
               } else {
                 report += `:white_check_mark: All ${coordChecked} coordinate(s) within expected country bounds\n`;
@@ -244,11 +256,14 @@ jobs:
             }
 
             // Duplicate Detection
-            if (dupChecked > 0 || dupWarnings.length > 0) {
+            if (dupChecked > 0 || dupWarningCount > 0) {
               report += '### Duplicate Detection\n';
-              if (dupWarnings.length > 0) {
+              if (dupWarningCount > 0) {
                 for (const warn of dupWarnings.slice(0, 10)) {
                   report += `- :warning: ${warn}\n`;
+                }
+                if (dupWarningCount > 10) {
+                  report += `- _...and ${dupWarningCount - 10} more potential duplicates_\n`;
                 }
               } else {
                 report += `:white_check_mark: No duplicates found among ${dupChecked} record(s)\n`;
@@ -269,8 +284,8 @@ jobs:
             }
 
             // Summary
-            const totalErrors = schemaErrorCount + crossrefErrors.length;
-            const totalWarnings = schemaWarningCount + coordWarnings.length + dupWarnings.length + urlErrors.length;
+            const totalErrors = schemaErrorCount + crossrefErrorCount;
+            const totalWarnings = schemaWarningCount + coordWarningCount + dupWarningCount + urlErrors.length;
 
             report += '---\n';
             if (needsClarification) {


### PR DESCRIPTION
## Problem

Follow-up to #1547. PR #1549 (UY normalisation, 2,010 rows) failed the validator — but not on its data (0 schema errors, 0 cross-ref errors). The **report step crashed** with:

```
##[error]An error occurred trying to start process 'node' ... Argument list too long
```

Root cause: `DUP_WARNINGS` was **303 KB**, exceeding the 128 KB per-env-var limit (`MAX_ARG_STRLEN`) when the report step spawned its node process. `#1547` capped the schema output but left the sibling validators uncapped — exactly the follow-up flagged in that PR.

A second issue compounded it: the cities schema's `optional` list omitted six standard fields, so every record logged 6 spurious "unknown field" warnings (UY: **12,060**).

## Fix

1. **Cap sibling validator outputs** (`detect-duplicates`, `validate-coordinates`, `validate-cross-reference`) at 50 entries, emitting a true `*_count` output alongside. The report step uses the counts for the summary totals and "...and N more" lines (same pattern as #1547's schema fix). `check-source-urls` is already bounded (≤5 URLs), left as-is.
2. **Complete the cities schema** `optional` list with `native`, `type`, `level`, `parent_id`, `population`, `translations` — standard canonical fields. Genuine unknown fields still warn.

## Verification (local)

- UY schema warnings: **12,060 → 0**; a genuinely unknown field still warns.
- All touched scripts pass `node --check`; workflow YAML validates.
- Capped lists keep every report env var well under the size limit.

## Note

This unblocks #1549 (UY) once that branch picks up these scripts. The PR data itself was always valid.