### PR TITLE
fix(ci): skip self-match in duplicate detection for existing-row edits

### DIFF
--- a/.github/scripts/detect-duplicates.js
+++ b/.github/scripts/detect-duplicates.js
@@ -100,6 +100,13 @@ async function run() {
       for (const existing of candidates) {
         if (!existing.name) continue;
 
+        // Skip self-comparison. For cities the candidate set is the same
+        // contributions file, so an edited record (which keeps its id) would
+        // otherwise match itself. New records carry no id and are unaffected.
+        if (record.id != null && existing.id != null && Number(existing.id) === Number(record.id)) {
+          continue;
+        }
+
         // Fuzzy name match
         const nameDist = levenshteinDistance(record.name, existing.name);
         const isNameMatch = nameDist <= NAME_DISTANCE_THRESHOLD;


### PR DESCRIPTION
## Problem

`detect-duplicates.js` loads the existing comparison set for cities from the **same** `contributions/cities/<CC>.json` file being edited. So when a PR edits existing rows (rather than adding new ones), every record matches **itself** — same `id`, identical name, 0.0km — and is flagged as a duplicate.

On #1549 (UY rename, 2,010 rows) this produced ~2,010 false "duplicate of itself" warnings, drowning out any real signal in the validation report.

## Fix

Skip the comparison when the candidate's `id` equals the record's `id`:

```js
if (record.id != null && existing.id != null && Number(existing.id) === Number(record.id)) {
  continue;
}
```

- **Edited rows** (carry an `id`) no longer self-match.
- **New rows** (no `id`) are unaffected — still checked against all existing records.
- **Genuine cross-record duplicates** (same/similar name, different `id`) are still flagged.

## Verification (local, against UY.json)

| | warnings |
|---|---|
| before (current prod) | 2,020 |
| after (same-id skip) | **10** |

The 10 remaining are genuine fuzzy near-matches (different ids, ≤2 edit distance, <5km) — exactly what the detector should surface for manual review. No exact same-name duplicates remain.

Completes the validator hardening from #1547 / #1550.