### PR TITLE
fix(ci): tolerate read-only token on fork PRs in validation report

### DIFF
--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -338,7 +338,8 @@ jobs:
                 });
               }
             } catch (err) {
-              core.warning(`Could not post validation comment (likely a fork PR with a read-only token): ${err.message}`);
+              const msg = err instanceof Error ? err.message : String(err);
+              core.warning(`Could not post validation comment (likely a fork PR with a read-only token): ${msg}`);
             }
 
             // Always surface the report in the job summary so it is visible

--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -303,36 +303,47 @@ jobs:
               report += 'Refer to our [Contribution Guidelines](https://github.com/dr5hn/countries-states-cities-database/blob/master/.github/CONTRIBUTING.md) for details.\n';
             }
 
-            // Find existing bot comment to update (avoid spam)
+            // Post (or update) the report comment. On PRs from forks the
+            // GITHUB_TOKEN is read-only, so comment writes throw "Resource not
+            // accessible by integration". Don't fail the validation over that —
+            // log a warning and rely on the job-summary fallback below.
             const COMMENT_MARKER = '## CSC Validation Report';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-
-            const botComment = comments.find(
-              (c) =>
-                (c.user.login === 'github-actions[bot]' || c.user.type === 'Bot') &&
-                c.body.includes(COMMENT_MARKER)
-            );
-
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: report,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: report,
+                per_page: 100,
               });
+
+              const botComment = comments.find(
+                (c) =>
+                  (c.user.login === 'github-actions[bot]' || c.user.type === 'Bot') &&
+                  c.body.includes(COMMENT_MARKER)
+              );
+
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body: report,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: report,
+                });
+              }
+            } catch (err) {
+              core.warning(`Could not post validation comment (likely a fork PR with a read-only token): ${err.message}`);
             }
+
+            // Always surface the report in the job summary so it is visible
+            // even when the comment cannot be posted (e.g. fork PRs).
+            await core.summary.addRaw(report).write();
 
             // Apply status labels
             const statusLabels = [];


### PR DESCRIPTION
## Problem

External contributors' PRs (#1555, #1557 from @ebarped, fixing the bad Spanish translations in #1556) showed the validator as **failed** — but their data was fine. Every real validation step passed (schema, cross-reference, coordinates, duplicates, source URLs); only **Post validation report** failed with:

```
##[error]Unhandled error: HttpError: Resource not accessible by integration
```

PRs from forks run with a **read-only `GITHUB_TOKEN`**, so the step's `createComment`/`updateComment` call is rejected. The label writes were already wrapped in try/catch (here and in `analyse-diff.js`), but the comment write was not — so it took down the whole job.

## Fix

- Wrap the comment post/update in `try/catch`; on failure log a warning instead of throwing.
- Always write the report to the **job summary** (`core.summary`) so it stays visible on fork PRs where the comment can't be posted.

Net effect: fork PRs now reflect the **actual data validation result** instead of a red X caused purely by comment-permission limits. Same-repo PRs are unchanged (comment still posts).

## Note

This unblocks #1555 and #1557 once they pick up the change. Their data was always valid.