### PR TITLE
fix(US): retype mis-classified settlements to 'city' (#1303 phase 1)

### DIFF
--- a/bin/scripts/fixes/retype_us_settlements.py
+++ b/bin/scripts/fixes/retype_us_settlements.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Phase 1 of issue #1303: retype mis-classified US settlements to 'city'.
+
+Many genuine US settlements were imported with GeoNames admin-level types
+instead of 'city':
+
+* ``adm2`` — county-seat towns (Abbeville, Abilene, ...) — real places
+* ``adm1`` — the 50 state capitals (Atlanta, Austin, Boston, ...)
+* ``adm3`` — minor civil-division towns (NJ/RI/MA)
+* ``cities`` — a plain typo of ``city``
+
+All of these are real populated places, so this retypes them to ``city``.
+It is a *type-only* change — no records are added, removed, or have any
+other field touched — so it is fully reversible.
+
+Out of scope (handled separately): ``county``/``parish`` (genuine admin
+units, Phase 2 drop-or-relocate decision) and ``abandoned``/null types.
+
+Idempotent. Run from the repo root.
+
+Usage
+-----
+    python3 bin/scripts/fixes/retype_us_settlements.py --dry-run
+    python3 bin/scripts/fixes/retype_us_settlements.py
+"""
+
+import argparse
+import collections
+import json
+import sys
+from pathlib import Path
+
+FILE = Path("contributions/cities/US.json")
+RETYPE_FROM = {"adm2", "adm1", "adm3", "cities"}
+RETYPE_TO = "city"
+
+
+def main() -> int:
+    """Apply (or preview) the US settlement retype."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="preview without writing")
+    args = parser.parse_args()
+
+    if not FILE.exists():
+        print(f"ERROR: {FILE} not found (run from repo root)", file=sys.stderr)
+        return 1
+
+    records = json.loads(FILE.read_text(encoding="utf-8"))
+    changed = collections.Counter()
+    for r in records:
+        if r.get("type") in RETYPE_FROM:
+            changed[r["type"]] += 1
+            r["type"] = RETYPE_TO
+
+    total = sum(changed.values())
+    print(f"{FILE}: {len(records)} rows, {total} retyped to '{RETYPE_TO}'")
+    for t, n in changed.most_common():
+        print(f"  {t} -> {RETYPE_TO}: {n}")
+
+    if args.dry_run:
+        print("\n(dry run — no changes written)")
+        return 0
+
+    FILE.write_text(json.dumps(records, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"\nWrote {FILE}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Phase 1 of #1303. Addresses the half of the problem where **real US settlements were mislabeled** with GeoNames admin types instead of `city`.

## Change (type-only, fully reversible)

| from | → to | count | what they are |
|------|------|------:|---------------|
| `adm2` | `city` | 2,995 | county-seat towns (Abbeville, Abilene, Abingdon…) |
| `adm1` | `city` | 50 | the 50 state capitals (Atlanta, Austin, Boston…) |
| `adm3` | `city` | 15 | NJ/RI/MA minor civil divisions |
| `cities` | `city` | 2 | typo |

**3,062 rows**, `type` field only — no records added/removed, no other fields touched. US `city` count: 13,318 → 16,380. Idempotent fixer at `bin/scripts/fixes/retype_us_settlements.py`.

## Verified
- Diff is exclusively `"type"` lines; row count unchanged (19,788).
- These are genuine settlements (only 4 `adm2` overlap an existing city — see below); dropping them would lose real places, so they're retyped, not removed.
- US postcodes carry no `city_id`, so no FK impact.

## Flagged for separate review (not changed here)
4 SC `adm2` rows share a state+name with an existing `city` and may be duplicates: **Allendale** (111193↔111197), **Barnwell** (111838↔111839), **Lancaster** (120081↔120090), **Lexington** (120443↔120453). Left as `city` for now; worth a dedup pass.

## Not in this PR — Phase 2
`county` (2,993) + `parish` (64) are genuine admin units. Pending your decision: **drop** them from cities, or **relocate** to a new `contributions/counties/US.json` dataset (matches the issue's "separately" ask, but needs validator + export plumbing).