### PR TITLE
Fix German translation for Nepal

### DIFF
--- a/contributions/countries/countries.json
+++ b/contributions/countries/countries.json
@@ -10333,7 +10333,7 @@
       "nl": "Nepal",
       "hr": "Nepal",
       "fa": "نپال",
-      "de": "Népal",
+      "de": "Nepal",
       "es": "Nepal",
       "fr": "Népal",
       "ja": "ネパール",


### PR DESCRIPTION
Corrected the German translation of 'Nepal' from 'Népal' to 'Nepal'.