### PR TITLE
fix(JP): correct Tokyo wikiDataId Q207309→Q1490 (#1576)

### DIFF
--- a/contributions/cities/JP.json
+++ b/contributions/cities/JP.json
@@ -52395,7 +52395,7 @@
     "created_at": "2019-10-06T10:07:41",
     "updated_at": "2025-12-02T14:39:31",
     "flag": 1,
-    "wikiDataId": "Q207309"
+    "wikiDataId": "Q1490"
   },
   {
     "id": 64501,


### PR DESCRIPTION
## Summary
Fixes the Wikidata ID for **Tokyo** (city `id 64500`).

- **Before:** `Q207309` — the *historical* City of Tokyo (Tokyo-shi), abolished in 1943.
- **After:** `Q1490` — the Wikidata item for present-day Tokyo (the metropolis).

Single-field change to `contributions/cities/JP.json`; all 1,655 JP records intact, JSON validates.

Reported via CSC Manager. Closes #1576.

## Source
- https://www.wikidata.org/wiki/Q1490 (Tokyo)
- https://www.wikidata.org/wiki/Q207309 (City of Tokyo, historical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)