### PR TITLE
feat(NZ): add Maungaturoto, Huntly, Otaua (closes #1592, #1591, #1590)

### DIFF
--- a/contributions/cities/NZ.json
+++ b/contributions/cities/NZ.json
@@ -6435,5 +6435,49 @@
     "updated_at": "2025-12-02T17:11:50",
     "flag": 1,
     "wikiDataId": "Q1972491"
+  },
+  {
+    "name": "Maungaturoto",
+    "state_id": 4059,
+    "state_code": "NTL",
+    "country_id": 158,
+    "country_code": "NZ",
+    "type": "city",
+    "level": null,
+    "parent_id": null,
+    "latitude": "-36.12955650",
+    "longitude": "174.34624500",
+    "native": "Maungaturoto",
+    "timezone": "Pacific/Auckland",
+    "wikiDataId": "Q3300200"
+  },
+  {
+    "name": "Huntly",
+    "state_id": 4061,
+    "state_code": "WKO",
+    "country_id": 158,
+    "country_code": "NZ",
+    "type": "city",
+    "level": null,
+    "parent_id": null,
+    "latitude": "-37.57972700",
+    "longitude": "175.15530700",
+    "native": "Huntly",
+    "timezone": "Pacific/Auckland",
+    "wikiDataId": "Q907941"
+  },
+  {
+    "name": "Otaua",
+    "state_id": 4061,
+    "state_code": "WKO",
+    "country_id": 158,
+    "country_code": "NZ",
+    "type": "city",
+    "level": null,
+    "parent_id": null,
+    "latitude": "-37.15085000",
+    "longitude": "174.65189930",
+    "native": "Otaua",
+    "timezone": "Pacific/Auckland"
   }
 ]


### PR DESCRIPTION
## Summary
Adds three New Zealand localities requested via issues, with FK integrity verified against `states.json`.

| Locality | Region | state_code / state_id | Notes |
|----------|--------|----------------------|-------|
| Maungaturoto | Northland | `NTL` / **4059** | Submitter used `state_id 4061` (Waikato) with the `NTL` code — mismatch. Corrected to Northland's id **4059**. |
| Huntly | Waikato | `WKO` / 4061 | FK consistent as submitted. |
| Otaua | Waikato | `WKO` / 4061 | FK consistent. `wikiDataId` omitted — the only Wikidata match `Q92787484` is the **Northland** Otaua (lat −35.5), not this Waikato locality (−37.15). |

## Verification
- ✅ JSON valid; 157 → 160 records (+3)
- ✅ All `state_id`↔`state_code` pairs consistent with `states.json` (NTL=4059, WKO=4061)
- ✅ Coordinates within NZ bounds; Wikidata coords confirm Maungaturoto/Huntly QIDs
- ✅ No duplicate names in `NZ.json`
- ✅ `timezone` = `Pacific/Auckland`; `type` = `city`
- Translations intentionally omitted rather than machine-translated (avoids the MT-garbage class of errors tracked in #1587)

Closes #1592
Closes #1591
Closes #1590

Sources: [Maungaturoto](https://en.wikipedia.org/wiki/Maungaturoto), [Huntly](https://en.wikipedia.org/wiki/Huntly,_New_Zealand), [Waikato District](https://en.wikipedia.org/wiki/Waikato_District)

🤖 Generated with [Claude Code](https://claude.com/claude-code)