### PR TITLE
fix(export): filter SQL Server INSERT columns to table schema (#1589)

### DIFF
--- a/.github/fixes-docs/FIX_1589_SUMMARY.md
+++ b/.github/fixes-docs/FIX_1589_SUMMARY.md
@@ -1,0 +1,60 @@
+# Fix Summary: SQL Server export INSERT/CREATE TABLE column mismatch
+
+## Issue Reference
+**Original Issue:** [#1589](https://github.com/dr5hn/countries-states-cities-database/issues/1589) — Incorrect data for sqlserver release v3.2-export.5
+
+## Executive Summary
+
+The generated SQL Server export (`sqlserver/*.sql`, `sqlserver/world.sql`) produced `INSERT`
+statements referencing columns that the accompanying `CREATE TABLE` definitions do not declare,
+causing imports to fail with "invalid column name" errors.
+
+## Root Cause
+
+`bin/Commands/ExportSqlServer.php` builds each table's `CREATE TABLE` from a hardcoded schema, but
+builds the `INSERT` column list dynamically from the JSON source:
+
+```php
+$columns = array_keys($data[0]);
+```
+
+The exported JSON (`json/states.json`, `json/cities.json`) carries **denormalized convenience
+fields** that are joins in the relational model, not stored columns:
+
+| Table  | Extra JSON field(s) with no matching column |
+|--------|---------------------------------------------|
+| states | `country_name`                              |
+| cities | `state_name`, `country_name`                |
+
+Because these fields have no column in `CREATE TABLE`, the generated `INSERT` statements are invalid.
+`countries`, `regions`, and `subregions` were unaffected (no extra fields).
+
+## Fix
+
+Restrict the `INSERT` column list to columns actually declared in the table schema. A new
+`getTableColumns()` helper parses the column names out of `generateTableSchema()` (single source of
+truth), and `generateSqlServerInsert()` intersects the JSON keys with them:
+
+```php
+$tableColumns = $this->getTableColumns($tableName);
+$columns = array_values(array_intersect(array_keys($data[0]), $tableColumns));
+```
+
+This keeps the SQL Server schema consistent with the canonical MySQL schema (the `*_name` fields
+remain obtainable via a join), rather than denormalizing one export format.
+
+## Verification
+
+Exercised the private methods against the real `json/` data via reflection:
+
+| Table     | Columns dropped from INSERT | Result |
+|-----------|-----------------------------|--------|
+| countries | *(none)*                    | unchanged |
+| states    | `country_name`              | INSERT now matches schema |
+| cities    | `state_name`, `country_name`| INSERT now matches schema |
+
+Every resulting `INSERT` column list is a subset of its `CREATE TABLE` column set. `php -l` passes.
+
+## Files Changed
+
+- `bin/Commands/ExportSqlServer.php` — add `getTableColumns()`; filter INSERT columns to the schema.

--- a/bin/Commands/ExportSqlServer.php
+++ b/bin/Commands/ExportSqlServer.php
@@ -172,13 +172,47 @@ class ExportSqlServer extends Command
         return $schemas[$table] ?? throw new \InvalidArgumentException("Unknown table: $table");
     }
 
+    /**
+     * Extract the ordered column names from a table's CREATE TABLE definition.
+     *
+     * Parsing the schema produced by generateTableSchema() keeps the insertable
+     * column set automatically in sync with the schema. Each column is matched as
+     * "<name> <SQL_TYPE> ...", which naturally excludes the CREATE TABLE,
+     * IF OBJECT_ID and CONSTRAINT lines.
+     *
+     * @return string[] Column names in declaration order.
+     */
+    private function getTableColumns(string $table): array
+    {
+        $schema = $this->generateTableSchema($table);
+        preg_match_all(
+            '/^\s*(\w+)\s+(?:INT|BIGINT|BIT|NVARCHAR|NCHAR|DECIMAL|DATETIME2)\b/mi',
+            $schema,
+            $matches
+        );
+
+        return $matches[1];
+    }
+
     private function generateSqlServerInsert(string $tableName, array $data): string
     {
         if (empty($data)) {
             return '';
         }
 
-        $columns = array_keys($data[0]);
+        // Restrict INSERT columns to those declared in the table schema. Source
+        // JSON carries denormalized convenience fields (e.g. country_name,
+        // state_name) that have no matching column in CREATE TABLE and would
+        // otherwise produce INSERT statements that fail on import (issue #1589).
+        $tableColumns = $this->getTableColumns($tableName);
+        $columns = array_values(array_intersect(array_keys($data[0]), $tableColumns));
+
+        if (empty($columns)) {
+            throw new \RuntimeException(
+                "No columns for table '$tableName' match between the JSON source and the schema."
+            );
+        }
+
         $sql = '';
 
         // Chunk the data into groups of 900 (leaving some margin below the 1000 limit)


### PR DESCRIPTION
## Problem
The SQL Server export generates `INSERT` statements referencing columns that the accompanying `CREATE TABLE` definitions don't declare, so imports fail with invalid-column errors (reported in #1589).

## Root cause
`ExportSqlServer.php` hardcodes each `CREATE TABLE` but derives the `INSERT` column list dynamically:
```php
$columns = array_keys($data[0]);
```
The exported JSON carries **denormalized convenience fields** (relational joins, not stored columns):

| Table  | Extra JSON field(s) → no matching column |
|--------|------------------------------------------|
| states | `country_name` |
| cities | `state_name`, `country_name` |

`countries` / `regions` / `subregions` were unaffected.

## Fix
Restrict INSERT columns to those declared in the schema. New `getTableColumns()` parses column names from `generateTableSchema()` (single source of truth); `generateSqlServerInsert()` intersects the JSON keys with them:
```php
$tableColumns = $this->getTableColumns($tableName);
$columns = array_values(array_intersect(array_keys($data[0]), $tableColumns));
```
This keeps the SQL Server schema consistent with the canonical MySQL schema (the `*_name` values remain reachable via a join) instead of denormalizing one export format.

## Verification
Exercised the private methods against the real `json/` data via reflection (`memory_limit=-1` for the 153k-row cities file):

| Table | Columns dropped from INSERT | Result |
|-------|-----------------------------|--------|
| countries | *(none)* | unchanged |
| states | `country_name` | INSERT matches schema |
| cities | `state_name`, `country_name` | INSERT matches schema |

Every resulting INSERT column list is a subset of its `CREATE TABLE`. `php -l` passes. Full details in `.github/fixes-docs/FIX_1589_SUMMARY.md`.

Closes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)