### PR TITLE
fix(IR): correct 204 machine-translated Persian native names (#1587)

### DIFF
--- a/.github/fixes-docs/FIX_1587_SUMMARY.md
+++ b/.github/fixes-docs/FIX_1587_SUMMARY.md
@@ -1,0 +1,39 @@
+# Fix Summary: Iranian city native names machine-translated
+
+## Issue Reference
+**Original Issue:** [#1587](https://github.com/dr5hn/countries-states-cities-database/issues/1587) — native names are incorrectly machine-translated
+
+## Executive Summary
+
+204 Iranian city records in `contributions/cities/IR.json` had `native` values that were **machine
+translations of the English name** rather than the correct Persian place name. Examples:
+
+| id | name | before (`native`) | meaning of garbage | after (`native`) |
+|----|------|-------------------|--------------------|------------------|
+| 135121 | Saveh | صرفه جویی کردن | "to economize" | ساوه |
+| 134774 | Semnan | نیمان | (nonsense) | سمنان |
+| 135140 | Yazd | نوشتن | "to write" | یزد |
+| 135142 | Zanjan | زنگ | "bell" | زنجان |
+| 135125 | Tabriz | خوشی | "pleasure" | تبریز |
+
+## Changes Made
+
+- **File:** `contributions/cities/IR.json`
+- **Records updated:** 204 (only the `native` field changed on each)
+- **Source of corrections:** issue #1587 (reporter-supplied, Persian Wikipedia)
+
+## Integrity Verification
+
+Each correction was matched to its record by primary-key `id`, then guarded by an English-name check
+before applying:
+
+| Check | Result |
+|-------|--------|
+| Correction rows in issue (deduped) | 204 unique ids |
+| `id` found in `IR.json` | 204 / 204 |
+| Record `name` matches issue's English name | 204 / 204 |
+| Record's existing `native` matched issue's "current" value | 204 / 204 |
+| Name mismatches / not-found (skipped) | 0 |
+
+The exact match across all four checks confirms the corrections target the intended records. Diff is
+204 insertions / 204 deletions, all on `native` lines; JSON re-validated at 1847 records.

--- a/contributions/cities/IR.json
+++ b/contributions/cities/IR.json
@@ -8170,7 +8170,7 @@
     "parent_id": null,
     "latitude": "36.21670000",
     "longitude": "45.48320000",
-    "native": "سارداش",
+    "native": "سردشت",
     "population": 118849,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -8293,7 +8293,7 @@
     "parent_id": null,
     "latitude": "35.97765000",
     "longitude": "52.68246000",
-    "native": "ساوادکوه",
+    "native": "سوادکوه",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -8334,7 +8334,7 @@
     "parent_id": null,
     "latitude": "33.83333000",
     "longitude": "48.16667000",
-    "native": "سللی",
+    "native": "سلسله",
     "population": 75559,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -8375,7 +8375,7 @@
     "parent_id": null,
     "latitude": "35.57691000",
     "longitude": "53.39205000",
-    "native": "نیمان",
+    "native": "سمنان",
     "population": 124826,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -8416,7 +8416,7 @@
     "parent_id": null,
     "latitude": "30.11650000",
     "longitude": "55.11860000",
-    "native": "شاهربابک",
+    "native": "شهربابک",
     "population": 51620,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -8498,7 +8498,7 @@
     "parent_id": null,
     "latitude": "35.48846000",
     "longitude": "51.34567000",
-    "native": "شاهراک الله حسن",
+    "native": "شهرک امام حسن",
     "population": 5394,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -8621,7 +8621,7 @@
     "parent_id": null,
     "latitude": "32.31667000",
     "longitude": "50.80000000",
-    "native": "شاهرکورد",
+    "native": "شهرکرد",
     "population": 315980,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -14279,7 +14279,7 @@
     "parent_id": null,
     "latitude": "32.40000000",
     "longitude": "60.08333000",
-    "native": "ساربی",
+    "native": "سربیشه",
     "population": 8715,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -14320,7 +14320,7 @@
     "parent_id": null,
     "latitude": "34.50000000",
     "longitude": "45.85000000",
-    "native": "سارپول زاهاب",
+    "native": "سرپل ذهاب",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -14361,7 +14361,7 @@
     "parent_id": null,
     "latitude": "29.21667000",
     "longitude": "53.13333000",
-    "native": "ساروستان",
+    "native": "سروستان",
     "population": 38114,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -14402,7 +14402,7 @@
     "parent_id": null,
     "latitude": "35.25000000",
     "longitude": "46.33333000",
-    "native": "سارو آباد",
+    "native": "سروآباد",
     "population": 5121,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -14525,7 +14525,7 @@
     "parent_id": null,
     "latitude": "38.18333000",
     "longitude": "47.98333000",
-    "native": "عالی",
+    "native": "سرعین",
     "population": 5459,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -14566,7 +14566,7 @@
     "parent_id": null,
     "latitude": "31.30000000",
     "longitude": "51.53333000",
-    "native": "نیم رو",
+    "native": "سمیرم",
     "population": 74109,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -14607,7 +14607,7 @@
     "parent_id": null,
     "latitude": "30.15000000",
     "longitude": "52.10000000",
-    "native": "سپ",
+    "native": "سپیدان",
     "population": 91049,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -14648,7 +14648,7 @@
     "parent_id": null,
     "latitude": "35.62828000",
     "longitude": "51.06632000",
-    "native": "شاهر",
+    "native": "شهریار",
     "population": 309607,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -14689,7 +14689,7 @@
     "parent_id": null,
     "latitude": "35.93141000",
     "longitude": "51.58997000",
-    "native": "شامیرانات",
+    "native": "شمیرانات",
     "population": 47279,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -14812,7 +14812,7 @@
     "parent_id": null,
     "latitude": "36.00000000",
     "longitude": "50.83333000",
-    "native": "ساوجبولغ",
+    "native": "ساوجبلاغ",
     "population": 259973,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -14894,7 +14894,7 @@
     "parent_id": null,
     "latitude": "26.50000000",
     "longitude": "57.18333000",
-    "native": "حسادت",
+    "native": "سیریک",
     "population": 5137,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -15017,7 +15017,7 @@
     "parent_id": null,
     "latitude": "28.88333000",
     "longitude": "51.26667000",
-    "native": "تانگستان",
+    "native": "تنگستان",
     "population": 76706,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -15099,7 +15099,7 @@
     "parent_id": null,
     "latitude": "37.90000000",
     "longitude": "48.78333000",
-    "native": "تذهیب",
+    "native": "تالش",
     "population": 200649,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -15140,7 +15140,7 @@
     "parent_id": null,
     "latitude": "34.73333000",
     "longitude": "60.73333000",
-    "native": "تائباد",
+    "native": "تایباد",
     "population": 56562,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -15181,7 +15181,7 @@
     "parent_id": null,
     "latitude": "38.59492000",
     "longitude": "46.46397000",
-    "native": "تنوع",
+    "native": "ورزقان",
     "population": 5348,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -15263,7 +15263,7 @@
     "parent_id": null,
     "latitude": "28.30000000",
     "longitude": "54.46667000",
-    "native": "زارین استپ",
+    "native": "زرین‌دشت",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -15304,7 +15304,7 @@
     "parent_id": null,
     "latitude": "35.28333000",
     "longitude": "59.73333000",
-    "native": "آیات",
+    "native": "زاوه",
     "population": 67695,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -15714,7 +15714,7 @@
     "parent_id": null,
     "latitude": "37.33333000",
     "longitude": "49.30000000",
-    "native": "برخی از سارا",
+    "native": "صومعه‌سرا",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -15755,7 +15755,7 @@
     "parent_id": null,
     "latitude": "36.20528000",
     "longitude": "50.77610000",
-    "native": "تالخان",
+    "native": "طالقان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16001,7 +16001,7 @@
     "parent_id": null,
     "latitude": "32.00890000",
     "longitude": "51.86680000",
-    "native": "شاهرزا",
+    "native": "شهرضا",
     "population": 134952,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16042,7 +16042,7 @@
     "parent_id": null,
     "latitude": "36.41819000",
     "longitude": "54.97628000",
-    "native": "شهود",
+    "native": "شاهرود",
     "population": 150129,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16165,7 +16165,7 @@
     "parent_id": null,
     "latitude": "30.64924000",
     "longitude": "48.66497000",
-    "native": "قانون",
+    "native": "شادگان",
     "population": 41733,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16206,7 +16206,7 @@
     "parent_id": null,
     "latitude": "36.67930000",
     "longitude": "46.56690000",
-    "native": "شاهین دج",
+    "native": "شاهین‌دژ",
     "population": 41442,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16247,7 +16247,7 @@
     "parent_id": null,
     "latitude": "32.85788000",
     "longitude": "51.55290000",
-    "native": "شاهین شاه",
+    "native": "شاهین‌شهر",
     "population": 173329,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16329,7 +16329,7 @@
     "parent_id": null,
     "latitude": "32.19420000",
     "longitude": "48.24360000",
-    "native": "خفه کردن",
+    "native": "شوش",
     "population": 52284,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16370,7 +16370,7 @@
     "parent_id": null,
     "latitude": "32.04972000",
     "longitude": "48.84843000",
-    "native": "ششتار",
+    "native": "شوشتر",
     "population": 77507,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16411,7 +16411,7 @@
     "parent_id": null,
     "latitude": "36.57914000",
     "longitude": "52.82364000",
-    "native": "شهرستان سیمورگ",
+    "native": "سیمرغ",
     "population": 19376,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16452,7 +16452,7 @@
     "parent_id": null,
     "latitude": "29.45137000",
     "longitude": "55.68090000",
-    "native": "سوری",
+    "native": "سیرجان",
     "population": 199704,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16493,7 +16493,7 @@
     "parent_id": null,
     "latitude": "33.75460000",
     "longitude": "46.56651000",
-    "native": "خدمت کردن",
+    "native": "سیروان",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16534,7 +16534,7 @@
     "parent_id": null,
     "latitude": "35.76841000",
     "longitude": "52.56091000",
-    "native": "صالح",
+    "native": "صلح‌بُن",
     "population": 1500,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16575,7 +16575,7 @@
     "parent_id": null,
     "latitude": "36.43235000",
     "longitude": "48.79393000",
-    "native": "سولتانیه",
+    "native": "سلطانیه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16616,7 +16616,7 @@
     "parent_id": null,
     "latitude": "34.78187000",
     "longitude": "47.59945000",
-    "native": "سرود",
+    "native": "سنقر",
     "population": 44256,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16657,7 +16657,7 @@
     "parent_id": null,
     "latitude": "35.02130000",
     "longitude": "50.35660000",
-    "native": "صرفه جویی کردن",
+    "native": "ساوه",
     "population": 175533,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16698,7 +16698,7 @@
     "parent_id": null,
     "latitude": "31.56350000",
     "longitude": "48.18958000",
-    "native": "سوزاندن",
+    "native": "سوسنگرد",
     "population": 51431,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16739,7 +16739,7 @@
     "parent_id": null,
     "latitude": "33.59586000",
     "longitude": "56.92437000",
-    "native": "متلاطم",
+    "native": "طبس",
     "population": 49993,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16780,7 +16780,7 @@
     "parent_id": null,
     "latitude": "32.80304000",
     "longitude": "60.22146000",
-    "native": "متلاطم",
+    "native": "طبس",
     "population": 39676,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16821,7 +16821,7 @@
     "parent_id": null,
     "latitude": "38.08000000",
     "longitude": "46.29190000",
-    "native": "خوشی",
+    "native": "تبریز",
     "population": 1424641,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16862,7 +16862,7 @@
     "parent_id": null,
     "latitude": "34.69307000",
     "longitude": "50.01601000",
-    "native": "تافروش",
+    "native": "تفرش",
     "population": 16493,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -16944,7 +16944,7 @@
     "parent_id": null,
     "latitude": "36.40090000",
     "longitude": "47.11330000",
-    "native": "توت",
+    "native": "تکاب",
     "population": 49677,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -17108,7 +17108,7 @@
     "parent_id": null,
     "latitude": "36.90000000",
     "longitude": "54.16667000",
-    "native": "تورکامان",
+    "native": "ترکمن",
     "population": 79978,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -17149,7 +17149,7 @@
     "parent_id": null,
     "latitude": "36.07057000",
     "longitude": "49.69571000",
-    "native": "ارباب",
+    "native": "تاکستان",
     "population": 80299,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -17190,7 +17190,7 @@
     "parent_id": null,
     "latitude": "32.70260000",
     "longitude": "51.15370000",
-    "native": "اژدها",
+    "native": "تیران",
     "population": 21703,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -17231,7 +17231,7 @@
     "parent_id": null,
     "latitude": "35.32420000",
     "longitude": "51.64570000",
-    "native": "دلهره",
+    "native": "ورامین",
     "population": 179603,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -17272,7 +17272,7 @@
     "parent_id": null,
     "latitude": "33.49083000",
     "longitude": "48.04917000",
-    "native": "وسی",
+    "native": "ویسیان",
     "population": 1817,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -17354,7 +17354,7 @@
     "parent_id": null,
     "latitude": "31.89722000",
     "longitude": "54.36750000",
-    "native": "نوشتن",
+    "native": "یزد",
     "population": 529673,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -17436,7 +17436,7 @@
     "parent_id": null,
     "latitude": "36.67642000",
     "longitude": "48.49628000",
-    "native": "زنگ",
+    "native": "زنجان",
     "population": 430871,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -17518,7 +17518,7 @@
     "parent_id": null,
     "latitude": "32.38970000",
     "longitude": "51.37660000",
-    "native": "شهر جری",
+    "native": "زرین‌شهر",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -17641,7 +17641,7 @@
     "parent_id": null,
     "latitude": "31.03060000",
     "longitude": "61.49490000",
-    "native": "اره",
+    "native": "زابل",
     "population": 134950,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34041,7 +34041,7 @@
     "parent_id": null,
     "latitude": "34.60166667",
     "longitude": "48.45055556",
-    "native": "حلقون",
+    "native": "سرکان",
     "population": 4081,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34082,7 +34082,7 @@
     "parent_id": null,
     "latitude": "34.57361111",
     "longitude": "48.15361111",
-    "native": "سازمانها",
+    "native": "سازیان",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34123,7 +34123,7 @@
     "parent_id": null,
     "latitude": "34.06972222",
     "longitude": "48.50805556",
-    "native": "سفیید خنه",
+    "native": "سفیدخانه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34492,7 +34492,7 @@
     "parent_id": null,
     "latitude": "35.37527778",
     "longitude": "49.20972222",
-    "native": "کالسکه",
+    "native": "شَوَند",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34533,7 +34533,7 @@
     "parent_id": null,
     "latitude": "34.80750000",
     "longitude": "48.57027778",
-    "native": "قاچاق",
+    "native": "شورین",
     "population": 514102,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34574,7 +34574,7 @@
     "parent_id": null,
     "latitude": "35.50222222",
     "longitude": "48.22250000",
-    "native": "شیخ جارا",
+    "native": "شیخ جراح",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34656,7 +34656,7 @@
     "parent_id": null,
     "latitude": "35.63333333",
     "longitude": "48.38250000",
-    "native": "غرب",
+    "native": "شیربرات",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34697,7 +34697,7 @@
     "parent_id": null,
     "latitude": "35.49277778",
     "longitude": "48.45055556",
-    "native": "برنامه آنها",
+    "native": "شیرین‌سو",
     "population": 2460,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34779,7 +34779,7 @@
     "parent_id": null,
     "latitude": "34.94583333",
     "longitude": "47.96833333",
-    "native": "سیاه",
+    "native": "سیاه‌گله",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34820,7 +34820,7 @@
     "parent_id": null,
     "latitude": "34.21694444",
     "longitude": "48.78472222",
-    "native": "همدیگر",
+    "native": "سیب‌در",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34902,7 +34902,7 @@
     "parent_id": null,
     "latitude": "34.68250000",
     "longitude": "48.58583300",
-    "native": "سیمین ابهام",
+    "native": "سیمین ابرو",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -34943,7 +34943,7 @@
     "parent_id": null,
     "latitude": "34.87666667",
     "longitude": "48.32166667",
-    "native": "شبیه زاغه",
+    "native": "سیمین زاغه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -35025,7 +35025,7 @@
     "parent_id": null,
     "latitude": "34.66333333",
     "longitude": "48.32055556",
-    "native": "سسته",
+    "native": "سیستانه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -35312,7 +35312,7 @@
     "parent_id": null,
     "latitude": "34.83860000",
     "longitude": "48.86640000",
-    "native": "سال",
+    "native": "طاحون‌آباد",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -35517,7 +35517,7 @@
     "parent_id": null,
     "latitude": "34.33670000",
     "longitude": "48.02250000",
-    "native": "تاپه از تابستان",
+    "native": "تپه یزدان",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -35722,7 +35722,7 @@
     "parent_id": null,
     "latitude": "35.16390000",
     "longitude": "48.48330000",
-    "native": "تاپه",
+    "native": "تاس‌تپه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -35763,7 +35763,7 @@
     "parent_id": null,
     "latitude": "34.56140000",
     "longitude": "48.79060000",
-    "native": "زبانه",
+    "native": "تسبندی",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -35845,7 +35845,7 @@
     "parent_id": null,
     "latitude": "35.15440000",
     "longitude": "49.04390000",
-    "native": "برگ معمول",
+    "native": "طواله",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -35886,7 +35886,7 @@
     "parent_id": null,
     "latitude": "34.21138900",
     "longitude": "48.18583300",
-    "native": "سقف",
+    "native": "توانه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -36173,7 +36173,7 @@
     "parent_id": null,
     "latitude": "35.49530000",
     "longitude": "48.95780000",
-    "native": "پالکی توپه",
+    "native": "تولکی‌تپه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -36255,7 +36255,7 @@
     "parent_id": null,
     "latitude": "34.51500000",
     "longitude": "49.02140000",
-    "native": "از همه پس",
+    "native": "توتال",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -36296,7 +36296,7 @@
     "parent_id": null,
     "latitude": "34.54805556",
     "longitude": "48.44666667",
-    "native": "تیزین",
+    "native": "تویسرکان",
     "population": 55708,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -36624,7 +36624,7 @@
     "parent_id": null,
     "latitude": "34.07920000",
     "longitude": "48.40560000",
-    "native": "دیافراگم",
+    "native": "وراینه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -36665,7 +36665,7 @@
     "parent_id": null,
     "latitude": "34.18640000",
     "longitude": "48.18610000",
-    "native": "واضه",
+    "native": "ورزنه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -36706,7 +36706,7 @@
     "parent_id": null,
     "latitude": "34.37170000",
     "longitude": "48.89780000",
-    "native": "جاذب",
+    "native": "ورچق",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -36747,7 +36747,7 @@
     "parent_id": null,
     "latitude": "34.70030000",
     "longitude": "48.29390000",
-    "native": "کف",
+    "native": "وردآورد سفلی",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -36829,7 +36829,7 @@
     "parent_id": null,
     "latitude": "34.67690000",
     "longitude": "48.61920000",
-    "native": "ولکان",
+    "native": "ورکانه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -36870,7 +36870,7 @@
     "parent_id": null,
     "latitude": "35.39640000",
     "longitude": "49.00920000",
-    "native": "وابسته به نقصان",
+    "native": "ورقستان",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37075,7 +37075,7 @@
     "parent_id": null,
     "latitude": "34.13860000",
     "longitude": "48.46830000",
-    "native": "گوش",
+    "native": "وشت",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37116,7 +37116,7 @@
     "parent_id": null,
     "latitude": "34.95810000",
     "longitude": "49.31250000",
-    "native": "راهنما",
+    "native": "وزندان",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37157,7 +37157,7 @@
     "parent_id": null,
     "latitude": "34.73640000",
     "longitude": "48.61110000",
-    "native": "نمک",
+    "native": "یالفان",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37198,7 +37198,7 @@
     "parent_id": null,
     "latitude": "35.06890000",
     "longitude": "49.38170000",
-    "native": "یاروم قاهله",
+    "native": "یاروم‌قیه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37239,7 +37239,7 @@
     "parent_id": null,
     "latitude": "35.51750000",
     "longitude": "48.67640000",
-    "native": "ایرلندی",
+    "native": "یارمجه‌باغ",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37280,7 +37280,7 @@
     "parent_id": null,
     "latitude": "34.80720000",
     "longitude": "48.63780000",
-    "native": "چانه",
+    "native": "یگانه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37362,7 +37362,7 @@
     "parent_id": null,
     "latitude": "34.87777800",
     "longitude": "49.00666700",
-    "native": "از هکله",
+    "native": "یکله",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37403,7 +37403,7 @@
     "parent_id": null,
     "latitude": "35.06110000",
     "longitude": "48.78360000",
-    "native": "سبز",
+    "native": "یسرلو",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37444,7 +37444,7 @@
     "parent_id": null,
     "latitude": "34.15860000",
     "longitude": "48.67330000",
-    "native": "یون",
+    "native": "یونس",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37485,7 +37485,7 @@
     "parent_id": null,
     "latitude": "34.35860000",
     "longitude": "48.78170000",
-    "native": "به طور قابل توجهی مستقیم",
+    "native": "یونجی",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37608,7 +37608,7 @@
     "parent_id": null,
     "latitude": "35.15280000",
     "longitude": "49.37580000",
-    "native": "زاغت",
+    "native": "زاغلیجه",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37690,7 +37690,7 @@
     "parent_id": null,
     "latitude": "34.14670000",
     "longitude": "49.01670000",
-    "native": "آنها به سمت داخل رفتند",
+    "native": "زنگنه سفلی",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37731,7 +37731,7 @@
     "parent_id": null,
     "latitude": "34.38390000",
     "longitude": "48.18940000",
-    "native": "بخار",
+    "native": "زاپن",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37813,7 +37813,7 @@
     "parent_id": null,
     "latitude": "34.29470000",
     "longitude": "48.05190000",
-    "native": "بسیاری از",
+    "native": "زرین‌باغ",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -37854,7 +37854,7 @@
     "parent_id": null,
     "latitude": "35.07140000",
     "longitude": "49.16940000",
-    "native": "زراع",
+    "native": "زرق",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -38223,7 +38223,7 @@
     "parent_id": null,
     "latitude": "37.73535540",
     "longitude": "46.93088980",
-    "native": "داش",
+    "native": "تکمه‌داش",
     "population": 2974,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -38346,7 +38346,7 @@
     "parent_id": null,
     "latitude": "38.03123850",
     "longitude": "46.12973630",
-    "native": "ساردر",
+    "native": "سردرود",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -38387,7 +38387,7 @@
     "parent_id": null,
     "latitude": "38.86877450",
     "longitude": "45.99665520",
-    "native": "کوشش",
+    "native": "سیه‌رود",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -38592,7 +38592,7 @@
     "parent_id": null,
     "latitude": "37.88192420",
     "longitude": "47.09549190",
-    "native": "وابسته به شرابی",
+    "native": "شربیان",
     "population": 4877,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -38674,7 +38674,7 @@
     "parent_id": null,
     "latitude": "38.31615040",
     "longitude": "45.33654190",
-    "native": "تغییر دادن",
+    "native": "تسوج",
     "population": 7522,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -38797,7 +38797,7 @@
     "parent_id": null,
     "latitude": "38.18273990",
     "longitude": "45.68192460",
-    "native": "سبرس",
+    "native": "شبستر",
     "population": 22181,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -38838,7 +38838,7 @@
     "parent_id": null,
     "latitude": "38.17865710",
     "longitude": "45.46786290",
-    "native": "غرفه",
+    "native": "شرفخانه",
     "population": 4244,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -38920,7 +38920,7 @@
     "parent_id": null,
     "latitude": "38.27831360",
     "longitude": "45.97709660",
-    "native": "وابسته به سوفی",
+    "native": "صوفیان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -39002,7 +39002,7 @@
     "parent_id": null,
     "latitude": "38.12844590",
     "longitude": "45.70490600",
-    "native": "وجنگان",
+    "native": "وایقان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -39248,7 +39248,7 @@
     "parent_id": null,
     "latitude": "38.58949510",
     "longitude": "45.82614190",
-    "native": "زونز",
+    "native": "زنوز",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -39576,7 +39576,7 @@
     "parent_id": null,
     "latitude": "37.58178980",
     "longitude": "47.37021430",
-    "native": "ترکمن چا",
+    "native": "ترکمانچای",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -39658,7 +39658,7 @@
     "parent_id": null,
     "latitude": "38.58136590",
     "longitude": "46.17000800",
-    "native": "وارزقن",
+    "native": "ورزقان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -40519,7 +40519,7 @@
     "parent_id": null,
     "latitude": "38.80220050",
     "longitude": "44.57706910",
-    "native": "زراد",
+    "native": "زورآباد",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -40847,7 +40847,7 @@
     "parent_id": null,
     "latitude": "39.22094680",
     "longitude": "44.74915970",
-    "native": "نشان دادن",
+    "native": "شوط",
     "population": 25381,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -41421,7 +41421,7 @@
     "parent_id": null,
     "latitude": "38.14643470",
     "longitude": "48.05716020",
-    "native": "سارین",
+    "native": "سرعین",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -41872,7 +41872,7 @@
     "parent_id": null,
     "latitude": "34.12406120",
     "longitude": "51.34705070",
-    "native": "سفر شاهر",
+    "native": "سفیدشهر",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -41954,7 +41954,7 @@
     "parent_id": null,
     "latitude": "33.44411680",
     "longitude": "52.46542430",
-    "native": "جوش",
+    "native": "زواره",
     "population": 8320,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -42118,7 +42118,7 @@
     "parent_id": null,
     "latitude": "32.72089190",
     "longitude": "52.65622610",
-    "native": "ابله",
+    "native": "تودشک",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -42200,7 +42200,7 @@
     "parent_id": null,
     "latitude": "32.51124460",
     "longitude": "51.92680470",
-    "native": "روزنامه",
+    "native": "زیار",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -42241,7 +42241,7 @@
     "parent_id": null,
     "latitude": "32.69866640",
     "longitude": "52.06674040",
-    "native": "سمی",
+    "native": "سجزی",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -42487,7 +42487,7 @@
     "parent_id": null,
     "latitude": "32.41767450",
     "longitude": "52.63817870",
-    "native": "جوش",
+    "native": "ورزنه",
     "population": 12714,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -42733,7 +42733,7 @@
     "parent_id": null,
     "latitude": "32.85028040",
     "longitude": "51.64761890",
-    "native": "گناه",
+    "native": "سین",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -43430,7 +43430,7 @@
     "parent_id": null,
     "latitude": "31.52755750",
     "longitude": "51.32147620",
-    "native": "وقن",
+    "native": "ونک",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -43922,7 +43922,7 @@
     "parent_id": null,
     "latitude": "32.59599600",
     "longitude": "51.48399340",
-    "native": "در زازا",
+    "native": "زازران",
     "population": 7962,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -44537,7 +44537,7 @@
     "parent_id": null,
     "latitude": "32.38257720",
     "longitude": "51.25747000",
-    "native": "زائنده",
+    "native": "زاینده‌رود",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -44578,7 +44578,7 @@
     "parent_id": null,
     "latitude": "32.41176360",
     "longitude": "51.36318620",
-    "native": "زرینشدر",
+    "native": "زرین‌شهر",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -44619,7 +44619,7 @@
     "parent_id": null,
     "latitude": "32.37447790",
     "longitude": "51.30912400",
-    "native": "ناهار",
+    "native": "سده لنجان",
     "population": 19101,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -44701,7 +44701,7 @@
     "parent_id": null,
     "latitude": "32.35522120",
     "longitude": "51.37205960",
-    "native": "لاکره",
+    "native": "ورنامخواست",
     "population": 18700,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -46136,7 +46136,7 @@
     "parent_id": null,
     "latitude": "33.72550000",
     "longitude": "47.06850000",
-    "native": "توری",
+    "native": "توحید",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -47079,7 +47079,7 @@
     "parent_id": null,
     "latitude": "29.15332260",
     "longitude": "51.51832580",
-    "native": "تاون",
+    "native": "تنگ ارم",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -47202,7 +47202,7 @@
     "parent_id": null,
     "latitude": "29.47081580",
     "longitude": "50.97548950",
-    "native": "تارا",
+    "native": "شبانکاره",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -47284,7 +47284,7 @@
     "parent_id": null,
     "latitude": "29.48645140",
     "longitude": "51.21830440",
-    "native": "شرور",
+    "native": "وحدتیه",
     "population": 11222,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -48596,7 +48596,7 @@
     "parent_id": null,
     "latitude": "35.57258130",
     "longitude": "51.42336480",
-    "native": "شاهر اری",
+    "native": "شهر ری",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -48678,7 +48678,7 @@
     "parent_id": null,
     "latitude": "35.80464930",
     "longitude": "51.43132060",
-    "native": "تاجیش",
+    "native": "تجریش",
     "population": 86000,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -48719,7 +48719,7 @@
     "parent_id": null,
     "latitude": "36.01128670",
     "longitude": "51.48654700",
-    "native": "شیمشاک",
+    "native": "شمشک",
     "population": 3423,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -49006,7 +49006,7 @@
     "parent_id": null,
     "latitude": "35.60483460",
     "longitude": "51.01625910",
-    "native": "واحد",
+    "native": "وحیدیه",
     "population": 33249,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -49621,7 +49621,7 @@
     "parent_id": null,
     "latitude": "32.52143210",
     "longitude": "50.39623970",
-    "native": "سعدی",
+    "native": "سودجان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -49662,7 +49662,7 @@
     "parent_id": null,
     "latitude": "32.31709400",
     "longitude": "50.67117690",
-    "native": "سورسیان",
+    "native": "سورشجان",
     "population": 12308,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -49744,7 +49744,7 @@
     "parent_id": null,
     "latitude": "32.28446520",
     "longitude": "50.88317860",
-    "native": "شهربار",
+    "native": "شهرکیان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -50277,7 +50277,7 @@
     "parent_id": null,
     "latitude": "32.04720560",
     "longitude": "50.80899950",
-    "native": "ساحلی",
+    "native": "شلمزار",
     "population": 6899,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -50728,7 +50728,7 @@
     "parent_id": null,
     "latitude": "32.80770990",
     "longitude": "60.21503440",
-    "native": "دستگاه را بزنید",
+    "native": "طبس مسینا",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -50892,7 +50892,7 @@
     "parent_id": null,
     "latitude": "33.42331970",
     "longitude": "59.80727440",
-    "native": "زان",
+    "native": "زهان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -50974,7 +50974,7 @@
     "parent_id": null,
     "latitude": "33.66052710",
     "longitude": "58.39830620",
-    "native": "سح قله",
+    "native": "سه‌قلعه",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -51015,7 +51015,7 @@
     "parent_id": null,
     "latitude": "32.49081810",
     "longitude": "59.48763620",
-    "native": "ساهربیش",
+    "native": "سربیشه",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -51466,7 +51466,7 @@
     "parent_id": null,
     "latitude": "31.80557260",
     "longitude": "59.99816170",
-    "native": "شستشو",
+    "native": "شوسف",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -51589,7 +51589,7 @@
     "parent_id": null,
     "latitude": "32.57384110",
     "longitude": "50.99270600",
-    "native": "شهاباد",
+    "native": "شهرآباد",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -51671,7 +51671,7 @@
     "parent_id": null,
     "latitude": "36.31474250",
     "longitude": "59.36767090",
-    "native": "توگابه",
+    "native": "طرقبه",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -52491,7 +52491,7 @@
     "parent_id": null,
     "latitude": "36.14784690",
     "longitude": "58.86142020",
-    "native": "سولتا آباد",
+    "native": "سلطان‌آباد",
     "population": 5932,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -52819,7 +52819,7 @@
     "parent_id": null,
     "latitude": "35.96042890",
     "longitude": "57.75027730",
-    "native": "قطب",
+    "native": "ششتمد",
     "population": 3108,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -52901,7 +52901,7 @@
     "parent_id": null,
     "latitude": "35.66218570",
     "longitude": "60.08599370",
-    "native": "سفیید آواز خواند",
+    "native": "سفیدسنگ",
     "population": 6129,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -53188,7 +53188,7 @@
     "parent_id": null,
     "latitude": "36.74907150",
     "longitude": "59.92741590",
-    "native": "شاهریزو",
+    "native": "شهرزو",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -53434,7 +53434,7 @@
     "parent_id": null,
     "latitude": "35.17244870",
     "longitude": "59.03391840",
-    "native": "ساقه",
+    "native": "شادمهر",
     "population": 3825,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -53926,7 +53926,7 @@
     "parent_id": null,
     "latitude": "37.34160420",
     "longitude": "56.87828070",
-    "native": "شال",
+    "native": "شوقان",
     "population": 2313,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -54090,7 +54090,7 @@
     "parent_id": null,
     "latitude": "37.22889760",
     "longitude": "58.29700970",
-    "native": "تصور",
+    "native": "تیتکانلو",
     "population": 3835,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -55033,7 +55033,7 @@
     "parent_id": null,
     "latitude": "31.40816250",
     "longitude": "48.78697870",
-    "native": "آزمایشگر",
+    "native": "شیبان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -55115,7 +55115,7 @@
     "parent_id": null,
     "latitude": "31.48771080",
     "longitude": "48.86967650",
-    "native": "ویزیت",
+    "native": "ویس",
     "population": 15312,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -55238,7 +55238,7 @@
     "parent_id": null,
     "latitude": "30.82916700",
     "longitude": "50.19833300",
-    "native": "مشورت",
+    "native": "تشان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -55607,7 +55607,7 @@
     "parent_id": null,
     "latitude": "32.29616570",
     "longitude": "48.42367890",
-    "native": "شمشیرباد",
+    "native": "شمس‌آباد",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -56140,7 +56140,7 @@
     "parent_id": null,
     "latitude": "32.04102720",
     "longitude": "48.79976690",
-    "native": "ساقه",
+    "native": "شوشتر",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -56222,7 +56222,7 @@
     "parent_id": null,
     "latitude": "32.02138900",
     "longitude": "48.79277800",
-    "native": "ستارگان",
+    "native": "سردارآباد",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -56878,7 +56878,7 @@
     "parent_id": null,
     "latitude": "36.42352420",
     "longitude": "48.24708800",
-    "native": "زارین آباد",
+    "native": "زرین‌آباد",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -56919,7 +56919,7 @@
     "parent_id": null,
     "latitude": "35.75856190",
     "longitude": "48.47152940",
-    "native": "زارین روود",
+    "native": "زرین‌رود",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -56960,7 +56960,7 @@
     "parent_id": null,
     "latitude": "36.23940950",
     "longitude": "48.54545110",
-    "native": "سوت",
+    "native": "سجاس",
     "population": 7037,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -57001,7 +57001,7 @@
     "parent_id": null,
     "latitude": "36.07305320",
     "longitude": "48.43168260",
-    "native": "سوگند",
+    "native": "سهرورد",
     "population": 6991,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -57616,7 +57616,7 @@
     "parent_id": null,
     "latitude": "35.46800540",
     "longitude": "53.20981120",
-    "native": "سکه",
+    "native": "سرخه",
     "population": 9951,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -58805,7 +58805,7 @@
     "parent_id": null,
     "latitude": "25.58250060",
     "longitude": "59.37785270",
-    "native": "برای اردک",
+    "native": "زرآباد",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -59174,7 +59174,7 @@
     "parent_id": null,
     "latitude": "31.03248980",
     "longitude": "52.83048390",
-    "native": "فرا گرفتن",
+    "native": "سورمق",
     "population": 3050,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -59215,7 +59215,7 @@
     "parent_id": null,
     "latitude": "31.19106770",
     "longitude": "52.50031460",
-    "native": "غوغا",
+    "native": "سُغاد",
     "population": 12582,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -59461,7 +59461,7 @@
     "parent_id": null,
     "latitude": "30.70291140",
     "longitude": "52.15963050",
-    "native": "نرم",
+    "native": "سده",
     "population": 0,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -59912,7 +59912,7 @@
     "parent_id": null,
     "latitude": "29.62961460",
     "longitude": "53.23294400",
-    "native": "سولتانشاهر",
+    "native": "سلطان‌شهر",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -60650,7 +60650,7 @@
     "parent_id": null,
     "latitude": "29.76307670",
     "longitude": "52.67474350",
-    "native": "زارگان",
+    "native": "زرقان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -60855,7 +60855,7 @@
     "parent_id": null,
     "latitude": "28.75180650",
     "longitude": "53.78289130",
-    "native": "زهدشهر",
+    "native": "زاهدشهر",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -60896,7 +60896,7 @@
     "parent_id": null,
     "latitude": "28.91250530",
     "longitude": "53.99227100",
-    "native": "شاشده",
+    "native": "ششده",
     "population": 5960,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -62044,7 +62044,7 @@
     "parent_id": null,
     "latitude": "30.00424490",
     "longitude": "53.00122260",
-    "native": "تلاش",
+    "native": "سیدان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -62372,7 +62372,7 @@
     "parent_id": null,
     "latitude": "27.46528850",
     "longitude": "53.04411650",
-    "native": "هستند",
+    "native": "وراوی",
     "population": 4622,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -62905,7 +62905,7 @@
     "parent_id": null,
     "latitude": "35.89536650",
     "longitude": "49.75102890",
-    "native": "درشت",
+    "native": "شال",
     "population": 15290,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -63192,7 +63192,7 @@
     "parent_id": null,
     "latitude": "36.64732350",
     "longitude": "49.18877350",
-    "native": "مخفیانه",
+    "native": "سیردان",
     "population": 805,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -63889,7 +63889,7 @@
     "parent_id": null,
     "latitude": "36.06053080",
     "longitude": "46.91183560",
-    "native": "زارین",
+    "native": "زرینه",
     "population": 2091,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -63930,7 +63930,7 @@
     "parent_id": null,
     "latitude": "35.25282120",
     "longitude": "46.25915770",
-    "native": "اورمان تاکت",
+    "native": "اورامان تخت",
     "population": 3176,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -64135,7 +64135,7 @@
     "parent_id": null,
     "latitude": "35.24963130",
     "longitude": "47.76967040",
-    "native": "دوباره آباد",
+    "native": "سریش‌آباد",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -64996,7 +64996,7 @@
     "parent_id": null,
     "latitude": "30.00024680",
     "longitude": "55.77831730",
-    "native": "شاهراک مس سرشیسم",
+    "native": "شهرک مس سرچشمه",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -65242,7 +65242,7 @@
     "parent_id": null,
     "latitude": "30.86833240",
     "longitude": "56.33342680",
-    "native": "شهر",
+    "native": "یزدان‌شهر",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -66103,7 +66103,7 @@
     "parent_id": null,
     "latitude": "30.40467220",
     "longitude": "56.89778550",
-    "native": "زنگباد",
+    "native": "زنگی‌آباد",
     "population": 8568,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -66144,7 +66144,7 @@
     "parent_id": null,
     "latitude": "30.42195570",
     "longitude": "57.69062500",
-    "native": "شهد",
+    "native": "شهداد",
     "population": 5217,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -66964,7 +66964,7 @@
     "parent_id": null,
     "latitude": "34.81151280",
     "longitude": "47.46012210",
-    "native": "ربودن",
+    "native": "سطر",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -67046,7 +67046,7 @@
     "parent_id": null,
     "latitude": "33.88124650",
     "longitude": "45.63190690",
-    "native": "یار",
+    "native": "سومار",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -67251,7 +67251,7 @@
     "parent_id": null,
     "latitude": "34.50537190",
     "longitude": "47.83984780",
-    "native": "سرتاسر",
+    "native": "سرمست",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -67579,7 +67579,7 @@
     "parent_id": null,
     "latitude": "30.80720400",
     "longitude": "50.84650350",
-    "native": "سارفاری",
+    "native": "سرفاریاب",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -67661,7 +67661,7 @@
     "parent_id": null,
     "latitude": "30.85631130",
     "longitude": "51.43766630",
-    "native": "سیزاکت",
+    "native": "سی‌سخت",
     "population": 7855,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -67743,7 +67743,7 @@
     "parent_id": null,
     "latitude": "30.85902050",
     "longitude": "50.45108550",
-    "native": "بازار",
+    "native": "سوق",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -68481,7 +68481,7 @@
     "parent_id": null,
     "latitude": "36.89138900",
     "longitude": "54.56916700",
-    "native": "سارخون کلات",
+    "native": "سرخون کلاته",
     "population": 7589,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -69178,7 +69178,7 @@
     "parent_id": null,
     "latitude": "36.89090440",
     "longitude": "49.52147480",
-    "native": "قاچاق",
+    "native": "توتکابن",
     "population": 1510,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -70449,7 +70449,7 @@
     "parent_id": null,
     "latitude": "33.49888900",
     "longitude": "48.70861100",
-    "native": "زغه",
+    "native": "زاغه",
     "population": 2776,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -71187,7 +71187,7 @@
     "parent_id": null,
     "latitude": "36.52138900",
     "longitude": "52.57555600",
-    "native": "جنجال",
+    "native": "زرگرمحله",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -71515,7 +71515,7 @@
     "parent_id": null,
     "latitude": "36.85088800",
     "longitude": "50.80323940",
-    "native": "شیرو",
+    "native": "شیرود",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -71966,7 +71966,7 @@
     "parent_id": null,
     "latitude": "36.29749850",
     "longitude": "52.86569940",
-    "native": "شیطان",
+    "native": "شیرگاه",
     "population": 8671,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -72253,7 +72253,7 @@
     "parent_id": null,
     "latitude": "36.59687210",
     "longitude": "53.20168030",
-    "native": "تشویق کردن",
+    "native": "سورک",
     "population": 9208,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -72581,7 +72581,7 @@
     "parent_id": null,
     "latitude": "34.41188360",
     "longitude": "49.49469560",
-    "native": "سارواگ",
+    "native": "ساروق",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -73196,7 +73196,7 @@
     "parent_id": null,
     "latitude": "34.04440970",
     "longitude": "49.28376670",
-    "native": "سرود",
+    "native": "توره",
     "population": 2302,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -73647,7 +73647,7 @@
     "parent_id": null,
     "latitude": "26.45871900",
     "longitude": "57.88425900",
-    "native": "ساردشت باشاگارد",
+    "native": "سردشت بشاگرد",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -73729,7 +73729,7 @@
     "parent_id": null,
     "latitude": "27.29016000",
     "longitude": "56.15210300",
-    "native": "وابسته به تازی",
+    "native": "تازیان",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -73770,7 +73770,7 @@
     "parent_id": null,
     "latitude": "27.50356930",
     "longitude": "56.62731160",
-    "native": "درشت",
+    "native": "تخت",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -74590,7 +74590,7 @@
     "parent_id": null,
     "latitude": "26.77724030",
     "longitude": "56.04379160",
-    "native": "سوسن",
+    "native": "سوزا",
     "population": 5707,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -74672,7 +74672,7 @@
     "parent_id": null,
     "latitude": "27.33793880",
     "longitude": "56.95310350",
-    "native": "درز",
+    "native": "تیرور",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -74713,7 +74713,7 @@
     "parent_id": null,
     "latitude": "26.83816290",
     "longitude": "57.41788730",
-    "native": "فرستاگر",
+    "native": "سندرک",
     "population": 1915,
     "timezone": "Asia/Tehran",
     "translations": {
@@ -75656,7 +75656,7 @@
     "parent_id": null,
     "latitude": "31.98615350",
     "longitude": "54.22491050",
-    "native": "زراخ",
+    "native": "زارچ",
     "population": null,
     "timezone": "Asia/Tehran",
     "translations": {


### PR DESCRIPTION
## Problem
204 Iranian city records in `contributions/cities/IR.json` had `native` values that were **machine translations of the English name** instead of the correct Persian place name.

| id | name | before (`native`) | meaning | after |
|----|------|-------------------|---------|-------|
| 135121 | Saveh | صرفه جویی کردن | "to economize" | ساوه |
| 134774 | Semnan | نیمان | (nonsense) | سمنان |
| 135140 | Yazd | نوشتن | "to write" | یزد |
| 135142 | Zanjan | زنگ | "bell" | زنجان |
| 135125 | Tabriz | خوشی | "pleasure" | تبریز |

## Corrections
Reporter-supplied (Persian Wikipedia) via #1587, applied by primary-key `id` with an English-`name` integrity guard.

| Check | Result |
|-------|--------|
| Correction rows in issue (deduped) | 204 unique ids |
| `id` found in `IR.json` | **204 / 204** |
| Record `name` matches issue's English name | **204 / 204** |
| Record's existing `native` matched issue's "current" value | **204 / 204** |
| Name mismatches / not-found (skipped) | 0 |

The exact match across all four checks confirms every correction targets the intended record.

## Verification
- ✅ Only the `native` field changed — **204 insertions / 204 deletions**, all on `native` lines
- ✅ JSON re-validated at **1847 records** (unchanged count)
- ✅ File encoding/formatting preserved (raw UTF-8, no whole-file reformat)

Details in `.github/fixes-docs/FIX_1587_SUMMARY.md`.

Closes #1587

🤖 Generated with [Claude Code](https://claude.com/claude-code)