### PR TITLE
fix: correct London parent_id from Scotland to England

### DIFF
--- a/contributions/states/states.json
+++ b/contributions/states/states.json
@@ -90357,7 +90357,7 @@
     "iso3166_2": "GB-LND",
     "type": "city",
     "level": 2,
-    "parent_id": 2335,
+    "parent_id": 2336,
     "native": "London",
     "latitude": "51.51234430",
     "longitude": "-0.09098520",


### PR DESCRIPTION
## Description

Corrects the `parent_id` of **London** (`GB-LND`, state `id 2424`) in `contributions/states/states.json` from `2335` (Scotland) to `2336` (England). Single-field change; no other record touched.

**Why England is correct:**

1. **Wikidata.** This record's `wikiDataId` is `Q23311` — the City of London — which is `located in the administrative territorial entity` of London (`Q23939248`), which is in turn `located in` **England**. The chain never passes through Scotland.

2. **This dataset's model.** GB is represented as a flat two-level hierarchy: the four home nations at `level 1`, and 217 ISO 3166-2 subdivisions at `level 2` parented directly to a home nation. There is no "London region" or "Greater London" record in `states.json`, so the intermediate Wikidata hop collapses and England is the correct parent.

## Type of Change
- [ ] Adding new data (cities/states/countries)
- [x] Correcting existing data
- [ ] Deleting data (requires justification)
- [ ] Infrastructure/Scripts
- [ ] Documentation
- [ ] Other (describe below)

## Data Source
**Source:**
- https://www.wikidata.org/wiki/Q23939248 — London (region of England) → `located in`: England
- https://www.wikidata.org/wiki/Q23311 — City of London → `located in`: London (Q23939248)

**Date Verified:** 2026-08-04

## Affected Entities
- **Country:** United Kingdom (`GB`, `country_id 232`)
- **State/Province:** London (`GB-LND`, `id 2424`)
- **Number of records:** 1

## Checklist
- [x] I have edited files only in the `contributions/` directory
- [x] I have NOT included `id`, `created_at`, `updated_at`, or `flag` fields
- [x] All required fields are present (name, coordinates, codes)
- [x] Data source is from a Tier 1 or Tier 2 source
- [x] Coordinates are verified and accurate
- [x] Verified data against reliable sources

## Related Issue
None.
