### PR TITLE
ci: upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/auto-changelog.yml
+++ b/.github/workflows/auto-changelog.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Slack notification
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,7 +20,7 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           submodules: true
@@ -31,13 +31,13 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: "8.2"
           extensions: intl #optional
           coverage: none
           ini-values: "post_max_size=256M, memory_limit=512M" #optional
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: bin/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('bin/composer.lock') }}

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           submodules: true
@@ -43,14 +43,14 @@ jobs:
           ini-values: "post_max_size=256M, memory_limit=512M" #optional
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: nmig/package-lock.json
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: bin/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('bin/composer.lock') }}
@@ -457,7 +457,7 @@ jobs:
           sed -i "s/Last Updated On: .*$/Last Updated On: $current_date/" README.md
 
       - name: Create GitHub Release with exports
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CURRENT_DATE: ${{ env.current_date }}
           REGION_COUNT: ${{ env.region_count }}
@@ -605,7 +605,7 @@ jobs:
             core.info('All export assets uploaded to release.');
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: |
             Export database formats - ${{ env.current_date }}

--- a/.github/workflows/issue-autoassign.yml
+++ b/.github/workflows/issue-autoassign.yml
@@ -17,7 +17,7 @@ jobs:
         if: |
           github.event.label.name == 'auto-fix' ||
           github.event.label.name == 'copilot'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issue = context.payload.issue;
@@ -60,7 +60,7 @@ jobs:
 
       - name: Label critical issues
         if: github.event.label.name == 'critical'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issue = context.payload.issue;
@@ -125,7 +125,7 @@ jobs:
 
       - name: Add template for data corrections
         if: github.event.label.name == 'data-correction'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Remove stale label on new activity
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {
@@ -39,10 +39,10 @@ jobs:
             }
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -106,7 +106,7 @@ jobs:
       # Post consolidated validation report
       - name: Post validation report
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_FORMAT_RESULTS: ${{ steps.pr_format.outputs.results }}
           PR_FORMAT_NEEDS_CLARIFICATION: ${{ steps.pr_format.outputs.needs_clarification }}
@@ -388,7 +388,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           DIFF_CRITICAL_REASONS: ${{ steps.diff.outputs.critical_reasons }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             if (!process.env.SLACK_WEBHOOK_URL) {
@@ -413,7 +413,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           DIFF_TOTAL_RECORDS: ${{ steps.diff.outputs.total_records }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             if (!process.env.SLACK_WEBHOOK_URL) {

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Create labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const labels = [

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Process stale PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:

--- a/.github/workflows/triage-repository.yml
+++ b/.github/workflows/triage-repository.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Triage open issues
         if: inputs.triage_issues
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;
@@ -155,7 +155,7 @@ jobs:
 
       - name: Triage open PRs
         if: inputs.triage_prs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;
@@ -294,7 +294,7 @@ jobs:
 
       - name: Send digest to Slack
         if: inputs.send_digest
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:

--- a/.github/workflows/weekly-digest.yml
+++ b/.github/workflows/weekly-digest.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: master
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate digest and update changelog
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:


### PR DESCRIPTION
## Summary
- upgrade JavaScript actions that still embed deprecated Node.js 20
- use the minimum compatible Node.js 24 action majors
- leave application dependencies and release versions unchanged
- fix the invalid single-version PHP matrix reference found by workflow linting

## Validation
- actionlint 1.7.12
- git diff --check
- verified all upgraded action metadata declares Node.js 24 (or composes only Node.js 24 actions)