### PR TITLE
fix(ci): stop duplicate validator comparing rows to themselves

### DIFF
--- a/.github/scripts/detect-duplicates.js
+++ b/.github/scripts/detect-duplicates.js
@@ -122,6 +122,14 @@ async function run() {
       continue;
     }
 
+    // County names commonly repeat across states. The previous loader did not
+    // provide county data, so keep that existing behavior until county-aware
+    // candidate filtering is implemented separately.
+    if (entityType === 'counties') {
+      core.info('County duplicate checking is not enabled.');
+      continue;
+    }
+
     // Contribution files are the current validation unit. Reuse the parsed
     // objects so an id-less new record can be distinguished from itself while
     // still being compared with every other record in the file.

--- a/.github/scripts/detect-duplicates.js
+++ b/.github/scripts/detect-duplicates.js
@@ -11,7 +11,6 @@ const path = require('path');
 const {
   getEntityType,
   parseJsonFile,
-  loadRepoData,
   haversineDistance,
   levenshteinDistance,
   normalizePostcodeCode,
@@ -57,6 +56,15 @@ function findPostcodeDuplicates(records) {
   }
 
   return { checked, duplicates };
+}
+
+/** Return true when a comparison points back to the same source record. */
+function isSelfComparison(record, existing) {
+  return record === existing || (
+    record.id != null &&
+    existing.id != null &&
+    Number(existing.id) === Number(record.id)
+  );
 }
 
 async function run() {
@@ -114,19 +122,10 @@ async function run() {
       continue;
     }
 
-    // Load existing data for comparison. For cities, use the country-specific
-    // contribution file instead of the 153k+ record aggregate.
-    let existingData = null;
-    if (entityType === 'cities') {
-      const countryCode = path.basename(filePath, '.json').toUpperCase();
-      const countryFilePath = path.join(process.cwd(), 'contributions', entityType, `${countryCode}.json`);
-      if (fs.existsSync(countryFilePath)) {
-        const { data: countryData } = parseJsonFile(countryFilePath);
-        existingData = countryData;
-      }
-    } else {
-      existingData = loadRepoData(entityType);
-    }
+    // Contribution files are the current validation unit. Reuse the parsed
+    // objects so an id-less new record can be distinguished from itself while
+    // still being compared with every other record in the file.
+    const existingData = records;
     if (!existingData || existingData.length === 0) {
       core.info(`No existing ${entityType} data found for duplicate check.`);
       continue;
@@ -155,10 +154,9 @@ async function run() {
       for (const existing of candidates) {
         if (!existing.name) continue;
 
-        // Skip self-comparison. For cities the candidate set is the same
-        // contributions file, so an edited record (which keeps its id) would
-        // otherwise match itself. New records carry no id and are unaffected.
-        if (record.id != null && existing.id != null && Number(existing.id) === Number(record.id)) {
+        // Skip the same source object or persisted id. Separate new records
+        // still compare with each other even though neither has an id yet.
+        if (isSelfComparison(record, existing)) {
           continue;
         }
 
@@ -219,4 +217,4 @@ async function run() {
 
 if (require.main === module) run().catch((err) => core.setFailed(err.message));
 
-module.exports = { findPostcodeDuplicates, postcodeKey };
+module.exports = { findPostcodeDuplicates, isSelfComparison, postcodeKey };

--- a/.github/scripts/detect-duplicates.test.js
+++ b/.github/scripts/detect-duplicates.test.js
@@ -2,7 +2,11 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { findPostcodeDuplicates, postcodeKey } = require('./detect-duplicates');
+const {
+  findPostcodeDuplicates,
+  isSelfComparison,
+  postcodeKey,
+} = require('./detect-duplicates');
 
 const base = {
   id: 1,
@@ -64,4 +68,16 @@ test('ignores records without a postcode code', () => {
     checked: 0,
     duplicates: [],
   });
+});
+
+test('skips only the same id-less source record', () => {
+  const record = { name: 'Al Barsha', latitude: '25.1055', longitude: '55.2086' };
+
+  assert.equal(isSelfComparison(record, record), true);
+  assert.equal(isSelfComparison(record, { ...record }), false);
+});
+
+test('skips existing records with the same id', () => {
+  assert.equal(isSelfComparison({ id: 10 }, { id: '10' }), true);
+  assert.equal(isSelfComparison({ id: 10 }, { id: 11 }), false);
 });


### PR DESCRIPTION
## Why

New contribution rows do not have database IDs yet. The duplicate validator reparsed the same file, compared each new row with its own copy, and reported false duplicate warnings.

## Fix

- reuse the already parsed contribution records
- skip the same source object or matching persisted ID
- keep comparing separate new rows, so real duplicates are still reported
- keep county duplicate checking disabled as before; county names commonly repeat across states and need separate state-aware logic
- add regression tests for new no-ID rows and existing IDs

## Validation

- 10 automation tests pass
- existing county behavior remains unchanged

This was reproduced on #1586, where the merge result contained one row per locality but the validator warned that each new no-ID row duplicated itself.